### PR TITLE
Parser now returns a list of strings for keys

### DIFF
--- a/lib/solid/argument.ex
+++ b/lib/solid/argument.ex
@@ -7,21 +7,20 @@ defmodule Solid.Argument do
   alias Solid.Context
 
   @doc """
-  iex> Solid.Argument.get({:field, "key"}, %Solid.Context{vars: %{"key" => 123}})
+  iex> Solid.Argument.get({:field, ["key"]}, %Solid.Context{vars: %{"key" => 123}})
   123
-  iex> Solid.Argument.get({:field, "key1.key2"}, %Solid.Context{vars: %{"key1" => %{"key2" => 123}}})
+  iex> Solid.Argument.get({:field, ["key1", "key2"]}, %Solid.Context{vars: %{"key1" => %{"key2" => 123}}})
   123
   iex> Solid.Argument.get({:value, "value"}, %Solid.Context{})
   "value"
-  iex> Solid.Argument.get({:field, "key", [{:access, 1},{:access, 1}]}, %Solid.Context{vars: %{"key" => [1, [1,2,3], 3]}})
+  iex> Solid.Argument.get({:field, ["key"], [{:access, 1},{:access, 1}]}, %Solid.Context{vars: %{"key" => [1, [1,2,3], 3]}})
   2
-  iex> Solid.Argument.get({:field, "key", [{:access, 1}]}, %Solid.Context{vars: %{"key" => "a string"}})
+  iex> Solid.Argument.get({:field, ["key"], [{:access, 1}]}, %Solid.Context{vars: %{"key" => "a string"}})
   nil
   """
-  @spec get({:field, String.t} | {:field, String.t, [{:access, non_neg_integer}]} | {:value, term}, Context.t) :: term
+  @spec get({:field, [String.t()]} | {:field, [String.t()], [{:access, non_neg_integer}]} | {:value, term}, Context.t) :: term
   def get({:value, val}, _hash), do: val
   def get({:field, key}, %Context{vars: vars}) do
-    key = key |> String.split(".")
     get_in(vars, key)
   end
   def get({:field, key, accesses}, context) do

--- a/lib/solid/tag.ex
+++ b/lib/solid/tag.ex
@@ -22,7 +22,7 @@ defmodule Solid.Tag do
 
   defp do_eval({:for_exp, exp}, context) do
     {enumerable, exp} = Keyword.pop_first(exp, :field)
-    {enumerable_value, exp} = Keyword.pop_first(exp, :field)
+    {[enumerable_value | _], exp} = Keyword.pop_first(exp, :field)
 
     {exp, _} = Keyword.pop_first(exp, :text)
     enumerable = Argument.get({:field, enumerable}, context) || []
@@ -83,6 +83,7 @@ defmodule Solid.Tag do
   end
 
   defp do_eval({:assign_exp, {:field, field}, argument}, context) do
+    [field | _] = field
     context = %{context | vars: Map.put(context.vars, field, Argument.get(argument, context))}
     {nil, context}
   end

--- a/src/solid_parser.peg
+++ b/src/solid_parser.peg
@@ -123,9 +123,9 @@ end
 argument <- value:value / field ~;
 field    <- [0-9a-zA-Z\._]* access* `
  case Node of
-   [FieldName | [[]]] -> {field, iolist_to_binary(FieldName)};
+   [FieldName | [[]]] -> {field, string:split(iolist_to_binary(FieldName), ".", all)};
    [FieldName | [Accesses]] ->
-     {field, iolist_to_binary(FieldName), Accesses}
+     {field, string:split(iolist_to_binary(FieldName), ".", all), Accesses}
  end
 `;
 access <- "[" int "]" `

--- a/test/object_test.exs
+++ b/test/object_test.exs
@@ -16,12 +16,12 @@ defmodule Solid.ObjectTest do
 
     test "field no filter" do
       context = %Context{vars: %{"var" => 1}}
-      assert render([argument: {:field, "var"}], context) == "1"
+      assert render([argument: {:field, ["var"]}], context) == "1"
     end
 
     test "field with filter" do
       context = %Context{vars: %{"var" => "a"}}
-      assert render([argument: {:field, "var"},
+      assert render([argument: {:field, ["var"]},
                      filters: [{"upcase", []}]], context) == "A"
     end
   end

--- a/test/tag_test.exs
+++ b/test/tag_test.exs
@@ -14,20 +14,20 @@ defmodule Solid.TagTest do
 
     test "eval case_exp matching" do
       context = %Context{ vars: %{ "x" => "1"}}
-      assert eval([{:case_exp, [{:field, "x"}]},
+      assert eval([{:case_exp, [{:field, ["x"]}]},
                    {:whens, %{ "1" => %{text: "one"} }}], context) == {"one", context}
     end
 
     test "eval case_exp not matching" do
       context = %Context{ vars: %{"x" => "1"}}
-      assert eval([{:case_exp, [{:field, "x"}]},
+      assert eval([{:case_exp, [{:field, ["x"]}]},
                    {:whens, %{ "2" => %{text: "two"} }}], context) == {nil, context}
     end
 
     test "eval case_exp not matching having else_exp" do
       context = %Context{ vars: %{ "x" => "1"}}
       else_exp = %{text: "else"}
-      assert eval([{:case_exp, [{:field, "x"}]},
+      assert eval([{:case_exp, [{:field, ["x"]}]},
                    {:whens, %{ "2" => %{text: "two"} }},
                    {:else_exp, else_exp}], context) == {"else", context}
     end


### PR DESCRIPTION
This moves the splitting of the key strings from `Argument.get` to the parser. This can optimize runtime if your strings are parsed at compile time.