### PR TITLE
fix: Get Custom Tags Working in Loops

### DIFF
--- a/lib/solid/tag.ex
+++ b/lib/solid/tag.ex
@@ -144,19 +144,19 @@ defmodule Solid.Tag do
       |> enumerable(context)
       |> apply_parameters(parameters)
 
-    do_for(enumerable_key, enumerable, exp, context)
+    do_for(enumerable_key, enumerable, exp, context, _options)
   end
 
   defp do_eval([raw_exp: raw], context, _options) do
     {[text: raw], context}
   end
 
-  defp do_for(_, [], exp, context) do
+  defp do_for(_, [], exp, context, _options) do
     exp = Keyword.get(exp, :else_exp)
     {exp[:result], context}
   end
 
-  defp do_for(enumerable_key, enumerable, exp, context) do
+  defp do_for(enumerable_key, enumerable, exp, context, options) do
     exp = Keyword.get(exp, :result)
     length = Enum.count(enumerable)
 
@@ -170,7 +170,7 @@ defmodule Solid.Tag do
           |> maybe_put_forloop_map(enumerable_key, index, length)
 
         try do
-          {result, acc_context} = Solid.render(exp, acc_context)
+          {result, acc_context} = Solid.render(exp, acc_context, options)
           acc_context = restore_initial_forloop_value(acc_context, acc_context_initial)
           {[result | acc_result], acc_context}
         catch

--- a/test/integration/custom_tag_test.exs
+++ b/test/integration/custom_tag_test.exs
@@ -33,5 +33,15 @@ defmodule Solid.Integration.CustomTagsTest do
              ) ==
                "2020-8-6"
     end
+
+    test "uses custom tags in loops" do
+      assert render(
+               ~w[{% for index in (1..3) %}{% get_year_of_date "202{{index}}-08-30T03:41:37Z" %} {% endfor %}]s,
+               %{},
+               tags: %{"get_year_of_date" => CustomTags.GetYearOfDate},
+               parser: CustomDateParser
+             ) ==
+               "2021-8-6 2022-8-6 2023-8-6"
+    end
   end
 end


### PR DESCRIPTION
I noticed that something like:

```liquid
{% for index in (1..3) %}
  {% custom_tag %}
{% endfor %}
```

Didn't work and was pulling my hair. Looks like this is something missing in my implementation. This PR aims to fix that.