### PR TITLE
Fix date integration test

### DIFF
--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -54,12 +54,12 @@ defmodule Solid.ContextTest do
     end
 
     test "map size" do
-      context = %Context{vars: %{"x" => %{ "a" => 1, "b" => 2}}}
+      context = %Context{vars: %{"x" => %{"a" => 1, "b" => 2}}}
       assert Context.get_in(context, ["x", "size"], [:vars]) == 2
     end
 
     test "map size key" do
-      context = %Context{vars: %{"x" => %{ "a" => 1, "b" => 2, "size" => 42}}}
+      context = %Context{vars: %{"x" => %{"a" => 1, "b" => 2, "size" => 42}}}
       assert Context.get_in(context, ["x", "size"], [:vars]) == 42
     end
   end

--- a/test/integration/custom_tag_test.exs
+++ b/test/integration/custom_tag_test.exs
@@ -23,7 +23,7 @@ defmodule Solid.Integration.CustomTagsTest do
                tags: %{"current_date" => CustomTags.CurrentDate},
                parser: CustomDateParser
              ) ==
-               "2020"
+               to_string(DateTime.utc_now().year)
     end
 
     test "pass in custom tag that needs arguments" do


### PR DESCRIPTION
There’s currently a test that compares the output of the custom `current_date` tag against the string `"2020"`.
This means that in 2021, the test is now failing. This MR fixes this by comparing against the current year from `DateTime.utc_now/0`.