### PR TITLE
Allow stringizing of maps in objects

### DIFF
--- a/lib/solid/object.ex
+++ b/lib/solid/object.ex
@@ -19,5 +19,9 @@ defmodule Solid.Object do
     |> Enum.join()
   end
 
+  defp stringify!(value) when is_map(value) and not is_struct(value) do
+    "#{inspect(value)}"
+  end
+
   defp stringify!(value), do: to_string(value)
 end

--- a/test/object_test.exs
+++ b/test/object_test.exs
@@ -13,6 +13,10 @@ defmodule Solid.ObjectTest do
       assert render([argument: [value: [1, [2, 3, [4, 5, "six"]]]]], %Context{}, []) == "12345six"
     end
 
+    test "map value no filter" do
+      assert render([argument: [value: %{"a" => "b"}]], %Context{}, []) == "%{\"a\" => \"b\"}"
+    end
+
     test "value with filter" do
       assert render(
                [argument: [value: "a"], filters: [filter: ["upcase", {:arguments, []}]]],


### PR DESCRIPTION
Previously, Solid raised when trying to render a map in an object.
This is contrary to the behavior of the Liquid gem where maps used as
objects are instead inspected/stringified.

Here is the behavior of the Liquid gem that this change also brings to Solid:

```ruby
template = Liquid::Template.parse("{{ person }}")
assigns = {"person" => {"name" => "Jane Doe"}}
template.render(assigns)
=> "{\"name\"=>\"Jane Doe\"}"

```