### PR TITLE
Allow first, last filters to work with non-lists

### DIFF
--- a/lib/solid/filter.ex
+++ b/lib/solid/filter.ex
@@ -236,7 +236,8 @@ defmodule Solid.Filter do
   nil
   """
   @spec first(list) :: any
-  def first(input), do: List.first(input)
+  def first(input) when is_list(input), do: List.first(input)
+  def first(_), do: nil
 
   @doc """
   Rounds a number down to the nearest whole number.
@@ -299,7 +300,8 @@ defmodule Solid.Filter do
   nil
   """
   @spec last(list) :: any
-  def last(input), do: List.last(input)
+  def last(input) when is_list(input), do: List.last(input)
+  def last(_), do: nil
 
   @doc """
   Removes all whitespaces (tabs, spaces, and newlines) from the beginning of a string.

--- a/test/cases/035/input.json
+++ b/test/cases/035/input.json
@@ -1,1 +1,1 @@
-{ "my_array" : [1, 2, 3] }
+{ "my_array" : [1, 2, 3], "string" : "A string" }

--- a/test/cases/035/input.liquid
+++ b/test/cases/035/input.liquid
@@ -1,1 +1,3 @@
 {{ my_array | first }}
+{{ string | first }}
+{{ does_not_exist | first }}

--- a/test/cases/037/input.json
+++ b/test/cases/037/input.json
@@ -1,1 +1,1 @@
-{ "my_array" : [1, 2, 3] }
+{ "my_array" : [1, 2, 3], "string" : "A string" }

--- a/test/cases/037/input.liquid
+++ b/test/cases/037/input.liquid
@@ -1,1 +1,3 @@
 {{ my_array | last }}
+{{ string | last }}
+{{ does_not_exist | last }}


### PR DESCRIPTION
Liquid does checking that the input responds to the list functions, this should be a safe version of that.

I am getting a failing test locally related to date, and it doesn't make any sense to me. It's unrelated to this PR as it happens on main.