### PR TITLE
Render custom tags inside of for loops and captures

### DIFF
--- a/lib/solid/tag.ex
+++ b/lib/solid/tag.ex
@@ -95,9 +95,9 @@ defmodule Solid.Tag do
   defp do_eval(
          [capture_exp: [field: [field_name], result: result]],
          context,
-         _options
+         options
        ) do
-    {captured, context} = Solid.render(result, context)
+    {captured, context} = Solid.render(result, context, options)
 
     context = %{
       context
@@ -137,26 +137,26 @@ defmodule Solid.Tag do
              ] = exp
          ],
          context,
-         _options
+         options
        ) do
     enumerable =
       enumerable
       |> enumerable(context)
       |> apply_parameters(parameters)
 
-    do_for(enumerable_key, enumerable, exp, context)
+    do_for(enumerable_key, enumerable, exp, context, options)
   end
 
   defp do_eval([raw_exp: raw], context, _options) do
     {[text: raw], context}
   end
 
-  defp do_for(_, [], exp, context) do
+  defp do_for(_, [], exp, context, _options) do
     exp = Keyword.get(exp, :else_exp)
     {exp[:result], context}
   end
 
-  defp do_for(enumerable_key, enumerable, exp, context) do
+  defp do_for(enumerable_key, enumerable, exp, context, options) do
     exp = Keyword.get(exp, :result)
     length = Enum.count(enumerable)
 
@@ -170,7 +170,7 @@ defmodule Solid.Tag do
           |> maybe_put_forloop_map(enumerable_key, index, length)
 
         try do
-          {result, acc_context} = Solid.render(exp, acc_context)
+          {result, acc_context} = Solid.render(exp, acc_context, options)
           acc_context = restore_initial_forloop_value(acc_context, acc_context_initial)
           {[result | acc_result], acc_context}
         catch

--- a/test/integration/custom_tag_test.exs
+++ b/test/integration/custom_tag_test.exs
@@ -14,6 +14,12 @@ defmodule Solid.Integration.CustomTagsTest do
         {:ok, dt, _} = DateTime.from_iso8601(dt_str)
         "#{dt.year}-#{dt.month}-#{dt.day}"
       end
+
+      def render(context, arguments: [field: [var_name]]) do
+        dt_str = Map.fetch!(context.iteration_vars, var_name)
+        {:ok, dt, _} = DateTime.from_iso8601(dt_str)
+        "#{dt.year}-#{dt.month}-#{dt.day}"
+      end
     end
   end
 
@@ -32,6 +38,42 @@ defmodule Solid.Integration.CustomTagsTest do
                parser: CustomDateParser
              ) ==
                "2020-8-6"
+    end
+
+    test "custom tags are evaluated inside of for loops" do
+      assert render(
+               "{% for date in dates %}<span>{% get_year_of_date date %}</span>{% endfor %}",
+               %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
+               tags: %{"get_year_of_date" => CustomTags.GetYearOfDate},
+               parser: CustomDateParser
+             ) == "<span>2020-8-6</span><span>2021-5-3</span>"
+    end
+
+    test "custom tags are evaluated inside of captures" do
+      assert render(
+               ~s({% capture testing %}{% get_year_of_date "2020-08-06T06:23:48Z" %}{% endcapture %}{{ testing }}),
+               %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
+               tags: %{"get_year_of_date" => CustomTags.GetYearOfDate},
+               parser: CustomDateParser
+             ) == "2020-8-6"
+    end
+
+    test "custom tags are evaluated inside of for loops and captures" do
+      rendered =
+        render(
+          """
+          {% capture testing %}
+            {% for date in dates %}<span>{% get_year_of_date date %}</span>{% endfor %}
+          {% endcapture %}
+
+          {{ testing }}
+          """,
+          %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
+          tags: %{"get_year_of_date" => CustomTags.GetYearOfDate},
+          parser: CustomDateParser
+        )
+
+      assert String.trim(rendered) == "<span>2020-8-6</span><span>2021-5-3</span>"
     end
   end
 end


### PR DESCRIPTION
The options were lost previously—this is where the custom tag definitions are stored. Without this, all custom
tags were skipped.