### PR TITLE
ensure custom_filters modules is loaded before checking if filter exists

### DIFF
--- a/lib/solid/filter.ex
+++ b/lib/solid/filter.ex
@@ -15,6 +15,7 @@ defmodule Solid.Filter do
   """
   def apply(filter, args) do
     custom_module = Application.get_env(:solid, :custom_filters, __MODULE__)
+    Code.ensure_loaded(custom_module)
 
     cond do
       filter_exists?({custom_module, filter, Enum.count(args)}) ->


### PR DESCRIPTION
We recently pushed our custom filters out of our main project and into a separate elixir project in order to reuse it with new projects. In doing so we noticed some tests began to fail. We were able to track it down to the fact that the module from the new shared dependency was not being loaded into the BEAM when Solid checks if the function exists.

This fixes that issue.