### PR TITLE
Tests, Add New assert_render helper

### DIFF
--- a/test/integration/cases_test.exs
+++ b/test/integration/cases_test.exs
@@ -18,9 +18,7 @@ for test_case <- File.ls!(cases_dir) do
       liquid_input = File.read!(@liquid_input_file)
       json_input = File.read!(@json_input_file)
 
-      solid_output = render(liquid_input, Jason.decode!(json_input), []) |> IO.iodata_to_binary()
-      {liquid_output, 0} = liquid_render(liquid_input, json_input)
-      assert liquid_output == solid_output
+      assert_render(liquid_input, json_input)
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,4 +20,35 @@ defmodule Solid.Helpers do
   def liquid_render(input_liquid, input_json) do
     System.cmd("ruby", ["test/liquid.rb", input_liquid, input_json])
   end
+
+  defmacro assert_render(liquid_input, json_input) do
+    quote do
+      solid_output =
+        render(unquote(liquid_input), Jason.decode!(unquote(json_input)), [])
+        |> IO.iodata_to_binary()
+
+      {liquid_output, 0} = liquid_render(unquote(liquid_input), unquote(json_input))
+
+      if liquid_output == solid_output do
+        true
+      else
+        message = """
+        Render result was different!
+        Input:
+        #{unquote(liquid_input)}
+        """
+
+        expr =
+          quote do
+            liquid_output == solid_output
+          end
+
+        raise ExUnit.AssertionError,
+          expr: expr,
+          left: liquid_output,
+          right: solid_output,
+          message: message
+      end
+    end
+  end
 end


### PR DESCRIPTION
While implementing [whitespace support](https://github.com/edgurgel/solid/pull/67) I came to the conclusion that it makes sense to [auto generate different whitespace trimming variants](https://github.com/edgurgel/solid/pull/67/files#diff-184a20c64c23513f3e8dd18847f5eb1a4dc6b0f2976c990175281f313b1006ca) of a given template to gain a good test coverage of edge cases while keeping test maintainable.

One problem I encountered, was that since the templates where generated I didn't know the actual input that was used when comparing the render results of liquid and solid.

My solution was adding a new `assert_render` macro that renders the template in liquid and solid and then compares them (as we do already with `cases_test`), but then includes the passed template in the assertion output if there is an missmatch.

I'm trying to keep the main patch for the whitespace support as small and reviewable as possible.
Since this particular change can stand alone and IMHO makes also sense outside of the context of whitespace support I've opened this PR.

Sample output:
```
  1) test case 113 (:"Elixir.Solid.Integration.Cases.113Test")
     test/integration/cases_test.exs:17
     Render result was different!
     Input:
     {% if enabled? %}
     ON
     {% else %}
     OFF
     {% endif %}

     code:  liquid_output == solid_output
     left:  "\nON\n\n"
     right: "\nOFF\n\n"
     stacktrace:
       test/integration/cases_test.exs:21: (test)
```