### PR TITLE
Add support for named arguments in filters

### DIFF
--- a/test/cases/114/input.json
+++ b/test/cases/114/input.json
@@ -1,0 +1,1 @@
+{ "input": "hello %{first_name}, %{last_name}", "surname": "john" }

--- a/test/cases/114/input.liquid
+++ b/test/cases/114/input.liquid
@@ -1,0 +1,1 @@
+{{ input | substitute: first_name: surname, last_name: 'doe' }}

--- a/test/integration/cases_test.exs
+++ b/test/integration/cases_test.exs
@@ -13,6 +13,18 @@ for test_case <- File.ls!(cases_dir) do
     @external_resource @liquid_input_file
     @external_resource @json_input_file
 
+    defmodule Solid.CustomFilters do
+      def substitute(message, bindings \\ %{}) do
+        Regex.replace(~r/%\{(\w+)\}/, message, fn _, key -> Map.get(bindings, key) end)
+      end
+    end
+
+    setup do
+      Application.put_env(:solid, :custom_filters, Solid.CustomFilters)
+
+      :ok
+    end
+
     @tag case: test_case
     test "case #{test_case}" do
       liquid_input = File.read!(@liquid_input_file)

--- a/test/integration/custom_filter_test.exs
+++ b/test/integration/custom_filter_test.exs
@@ -19,6 +19,10 @@ defmodule Solid.Integration.CustomFiltersTest do
 
     def date_format(date, _format),
       do: to_string(date)
+
+    def substitute(message, bindings \\ %{}) do
+      Regex.replace(~r/%\{(\w+)\}/, message, fn _, key -> Map.get(bindings, key) end)
+    end
   end
 
   setup do
@@ -42,10 +46,19 @@ defmodule Solid.Integration.CustomFiltersTest do
     end
 
     test "date format with malformed format", %{date: date} do
-      assert render(
-               ~s<{{ date_var | date_format: "x/y/z" }}>,
-               %{"date_var" => date} == "2019-10-31"
-             )
+      assert render(~s<{{ date_var | date_format: "x/y/z" }}>, %{"date_var" => date}) ==
+               "2019-10-31"
+    end
+
+    test "substitute without bindings" do
+      assert render(~s<{{ "hello world" | substitute }}>)
+    end
+
+    test "substitute with bindings", %{date: date} do
+      assert render(~s<{{ "today is %{today}" | substitute: today: date_var }}>, %{
+               "date_var" => date
+             }) ==
+               "today is 2019-10-31"
     end
   end
 end

--- a/test/liquid.rb
+++ b/test/liquid.rb
@@ -1,4 +1,13 @@
 require 'liquid'
 require 'json'
-hash = JSON.parse(ARGV[1])
-puts Liquid::Template.parse(ARGV[0]).render(hash)
+
+module SubstituteFilter
+  def substitute(input, params = {})
+    input.gsub(/%\{(\w+)\}/) { |_match| params[Regexp.last_match(1)] }
+  end
+end
+
+context = Liquid::Context.new(JSON.parse(ARGV[1]))
+context.add_filters(SubstituteFilter)
+
+puts Liquid::Template.parse(ARGV[0]).render(context)


### PR DESCRIPTION
Adding as per:

https://github.com/Shopify/liquid/blob/50d1a2ffc91e69c26af2eea278cbc9c4930126a9/lib/liquid/variable.rb#L16-L17

[used by Shopify to translate strings with variable replacements](https://shopify.dev/tutorials/develop-theme-localization-use-translation-keys)