### PR TITLE
fix bug that prevented using `false` as an argument

### DIFF
--- a/lib/solid/argument.ex
+++ b/lib/solid/argument.ex
@@ -19,6 +19,12 @@ defmodule Solid.Argument do
   nil
   iex> Solid.Argument.get([field: ["key", 1, "foo"]], %Solid.Context{vars: %{"key" => [%{"foo" => "bar1"}, %{"foo" => "bar2"}]}})
   "bar2"
+  iex> Solid.Argument.get([field: ["value"]], %Solid.Context{vars: %{"value" => nil}})
+  nil
+  iex> Solid.Argument.get([field: ["value"]], %Solid.Context{vars: %{"value" => false}})
+  false
+  iex> Solid.Argument.get([field: ["value"]], %Solid.Context{vars: %{"value" => true}})
+  true
   """
   @spec get([field: [String.t() | integer]] | [value: term], Context.t(), Keyword.t()) :: term
   def get(arg, context, opts \\ []) do

--- a/lib/solid/context.ex
+++ b/lib/solid/context.ex
@@ -18,12 +18,12 @@ defmodule Solid.Context do
   @spec get_in(t(), [term()], [scope]) :: term
   def get_in(context, key, scopes) do
     {:ok, result} =
-    scopes
-    |> Enum.map(&get_from_scope(context, &1, key))
-    |> Enum.find({:ok, nil}, fn
-      {:ok, _} -> true
-      _ -> false
-    end)
+      scopes
+      |> Enum.map(&get_from_scope(context, &1, key))
+      |> Enum.find({:ok, nil}, fn
+        {:ok, _} -> true
+        _ -> false
+      end)
 
     result
   end

--- a/test/cases/114/input.json
+++ b/test/cases/114/input.json
@@ -1,0 +1,3 @@
+{
+  "enabled?": false
+}

--- a/test/cases/114/input.liquid
+++ b/test/cases/114/input.liquid
@@ -1,0 +1,5 @@
+{% if enabled? == false %}
+ON
+{% else %}
+OFF
+{% endif %}

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -13,6 +13,16 @@ defmodule Solid.ContextTest do
       assert Context.get_in(context, ["x"], [:vars]) == 1
     end
 
+    test "var scope with false value" do
+      context = %Context{vars: %{"x" => false}}
+      assert Context.get_in(context, ["x"], [:vars]) == false
+    end
+
+    test "var scope with nil value" do
+      context = %Context{vars: %{"x" => nil}}
+      assert Context.get_in(context, ["x"], [:vars]) == nil
+    end
+
     test "iteration_vars scope only" do
       context = %Context{iteration_vars: %{"x" => 1}}
       assert Context.get_in(context, ["x"], [:iteration_vars]) == 1


### PR DESCRIPTION
Shout out to @barkerja for finding and debugging this to find it was related to `Solid.Argument.get/3` 📣 🎩 🙇 

We discovered this due to a template doing the opposite of what we expected:

```elixir
iex(27)> Solid.parse!("{% if value == true %}true{% else %}false{% endif %}") |> Solid.render(%{"value" => true}) |> to_string
"true"
iex(28)> Solid.parse!("{% if value == false %}false{% else %}true{% endif %}") |> Solid.render(%{"value" => false}) |> to_string
"true"
```

The root cause is the use of [`Enum.find_value/3`](https://hexdocs.pm/elixir/Enum.html#find_value/3).

> The return value is considered to be found when the result is truthy (_neither nil nor false_).

I don't think my solution is particularly elegant, so if you want to refactor it a bit I won't be offended.  This is technically less efficient since it won't short circuit if multiple scopes are provided (and a value is found in the first one), but it seems that the cost should be negligible.