### PR TITLE
Allow developer to customize parser freely

### DIFF
--- a/test/support/custom_parsers.ex
+++ b/test/support/custom_parsers.ex
@@ -5,3 +5,27 @@ end
 defmodule CustomFooParser do
   use Solid.Parser.Base, custom_tags: ["foobar", "foobarval"]
 end
+
+defmodule CustomIncludeParser do
+  use Solid.Parser.Base
+
+  space = string(" ") |> times(min: 0)
+
+  include =
+    ignore(string("{%"))
+    |> ignore(space)
+    |> concat(string("include"))
+    |> ignore(space)
+    |> tag(@argument, :template)
+    |> optional(
+      ignore(string(","))
+      |> ignore(space)
+      |> concat(@named_arguments)
+      |> tag(:arguments)
+    )
+    |> ignore(space)
+    |> ignore(string("%}"))
+    |> tag(:custom_tag)
+
+  @custom_tags [include]
+end


### PR DESCRIPTION
- Now developer can define their own tag and the way they want to parser it

This is how this ticket is implement

1. move `defcombinator` and `defparsec` to `__before_compile__` macro
2. change some variable to module attribute, so that they can be reused by
developer and we also can use them in `__before_compile__` macro
3. in `__before_compile__` macro, we concatenate `@base_tag` and `@custom_tags`
which defined in `__using__` macro
4. User can add more custom tag by redefine Module attribute `@custom_tags`, it
must be a list.

**List of expose attributes**
- @field
- `@value`
- `@argument`
- `@named_argumen`
- `@text`
- `@positional_arguments`
- `@named_arguments`
- `@object`
- `@base_tags`
- `@custom_tag`

**Example from test**

```elixir
defmodule CustomIncludeParser do
  use Solid.Parser.Base

  space = string(" ") |> times(min: 0)

  include =
    ignore(string("{%"))
    |> ignore(space)
    |> concat(string("include"))
    |> ignore(space)
    |> tag(@argument, :template)
    |> optional(
      ignore(string(","))
      |> ignore(space)
      |> concat(@named_arguments)
      |> tag(:arguments)
    )
    |> ignore(space)
    |> ignore(string("%}"))
    |> tag(:custom_tag)

  @custom_tags [include]
end

```