### PR TITLE
Implement tag behaviour for extend custom tag easier

### DIFF
--- a/lib/solid/parser/argument.ex
+++ b/lib/solid/parser/argument.ex
@@ -1,0 +1,44 @@
+defmodule Solid.Parser.Argument do
+  import NimbleParsec
+  alias Solid.Parser.{Variable, Literal}
+
+  defp space(), do: Literal.whitespace(min: 0)
+
+  def argument_name() do
+    ascii_string([?a..?z, ?A..?Z], 1)
+    |> concat(ascii_string([?a..?z, ?A..?Z, ?_], min: 0))
+    |> reduce({Enum, :join, []})
+  end
+
+  def argument, do: choice([Literal.value(), Variable.field()])
+
+  def named_argument() do
+    argument_name()
+    |> ignore(string(":"))
+    |> ignore(space())
+    |> choice([Literal.value(), Variable.field()])
+  end
+
+  def positional_arguments() do
+    argument()
+    |> repeat(
+      ignore(space())
+      |> ignore(string(","))
+      |> ignore(space())
+      |> concat(argument())
+    )
+  end
+
+  def named_arguments() do
+    named_argument()
+    |> repeat(
+      ignore(space())
+      |> ignore(string(","))
+      |> ignore(space())
+      |> concat(named_argument())
+    )
+    |> tag(:named_arguments)
+  end
+
+  def arguments(), do: choice([named_arguments(), positional_arguments()])
+end

--- a/lib/solid/parser/variable.ex
+++ b/lib/solid/parser/variable.ex
@@ -1,0 +1,23 @@
+defmodule Solid.Parser.Variable do
+  import NimbleParsec
+  alias Solid.Parser.Literal
+
+  defp identifier(), do: ascii_string([?a..?z, ?A..?Z, ?0..?9, ?_, ?-, ??], min: 1)
+
+  def bracket_access do
+    ignore(string("["))
+    |> choice([Literal.int(), Literal.single_quoted_string(), Literal.double_quoted_string()])
+    |> ignore(string("]"))
+  end
+
+  def dot_access do
+    ignore(string("."))
+    |> concat(identifier())
+  end
+
+  def field do
+    identifier()
+    |> repeat(choice([dot_access(), bracket_access()]))
+    |> tag(:field)
+  end
+end

--- a/test/integration/custom_tag_test.exs
+++ b/test/integration/custom_tag_test.exs
@@ -108,5 +108,21 @@ defmodule Solid.Integration.CustomTagsTest do
 
       assert String.trim(rendered) == "<span>2020-8-6</span><span>2021-5-3</span>"
     end
+
+    test "custom block wrap bracket" do
+      rendered =
+        render(
+          """
+          {% myblock %}
+          {{- "hello" -}}
+          {% endmyblock %}
+          """,
+          %{},
+          tags: %{"myblock" => CustomTags.CustomBrackedWrappedTag},
+          parser: CustomDateParser
+        )
+
+      assert String.trim(rendered) == "[[hello]]"
+    end
   end
 end

--- a/test/integration/custom_tag_test.exs
+++ b/test/integration/custom_tag_test.exs
@@ -2,27 +2,6 @@ defmodule Solid.Integration.CustomTagsTest do
   use ExUnit.Case, async: true
   import Solid.Helpers
 
-  defmodule CustomTags do
-    defmodule CurrentDate do
-      def render(_context, _arguments) do
-        DateTime.utc_now().year |> to_string
-      end
-    end
-
-    defmodule GetYearOfDate do
-      def render(_context, arguments: [value: dt_str]) do
-        {:ok, dt, _} = DateTime.from_iso8601(dt_str)
-        "#{dt.year}-#{dt.month}-#{dt.day}"
-      end
-
-      def render(context, arguments: [field: [var_name]]) do
-        dt_str = Map.fetch!(context.iteration_vars, var_name)
-        {:ok, dt, _} = DateTime.from_iso8601(dt_str)
-        "#{dt.year}-#{dt.month}-#{dt.day}"
-      end
-    end
-  end
-
   describe "custom tags" do
     test "pass in custom tag that needs no arguments" do
       assert render("{% current_date %}", %{},
@@ -70,6 +49,60 @@ defmodule Solid.Integration.CustomTagsTest do
           """,
           %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
           tags: %{"get_year_of_date" => CustomTags.GetYearOfDate},
+          parser: CustomDateParser
+        )
+
+      assert String.trim(rendered) == "<span>2020-8-6</span><span>2021-5-3</span>"
+    end
+  end
+
+  describe "custom tags modules" do
+    test "pass in custom tag that needs no arguments" do
+      assert render("{% get_current_date %}", %{},
+               tags: %{"get_current_date" => CustomTags.CurrentDate},
+               parser: CustomDateParser
+             ) ==
+               to_string(DateTime.utc_now().year)
+    end
+
+    test "pass in custom tag that needs arguments" do
+      assert render(~s({% get_year "2020-08-06T06:23:48Z" %}), %{},
+               tags: %{"get_year" => CustomTags.GetYearOfDate},
+               parser: CustomDateParser
+             ) ==
+               "2020-8-6"
+    end
+
+    test "custom tags are evaluated inside of for loops" do
+      assert render(
+               "{% for date in dates %}<span>{% get_year date %}</span>{% endfor %}",
+               %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
+               tags: %{"get_year" => CustomTags.GetYearOfDate},
+               parser: CustomDateParser
+             ) == "<span>2020-8-6</span><span>2021-5-3</span>"
+    end
+
+    test "custom tags are evaluated inside of captures" do
+      assert render(
+               ~s({% capture testing %}{% get_year "2020-08-06T06:23:48Z" %}{% endcapture %}{{ testing }}),
+               %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
+               tags: %{"get_year" => CustomTags.GetYearOfDate},
+               parser: CustomDateParser
+             ) == "2020-8-6"
+    end
+
+    test "custom tags are evaluated inside of for loops and captures" do
+      rendered =
+        render(
+          """
+          {% capture testing %}
+            {% for date in dates %}<span>{% get_year date %}</span>{% endfor %}
+          {% endcapture %}
+
+          {{ testing }}
+          """,
+          %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
+          tags: %{"get_year" => CustomTags.GetYearOfDate},
           parser: CustomDateParser
         )
 

--- a/test/support/custom_parsers.ex
+++ b/test/support/custom_parsers.ex
@@ -1,5 +1,11 @@
 defmodule CustomDateParser do
-  use Solid.Parser.Base, custom_tags: ["current_date", "get_year_of_date"]
+  use Solid.Parser.Base,
+    custom_tags: [
+      "current_date",
+      "get_year_of_date",
+      {"get_current_date", CustomTags.CurrentDate},
+      {"get_year", CustomTags.GetYearOfDate}
+    ]
 end
 
 defmodule CustomFooParser do

--- a/test/support/custom_parsers.ex
+++ b/test/support/custom_parsers.ex
@@ -4,7 +4,8 @@ defmodule CustomDateParser do
       "current_date",
       "get_year_of_date",
       {"get_current_date", CustomTags.CurrentDate},
-      {"get_year", CustomTags.GetYearOfDate}
+      {"get_year", CustomTags.GetYearOfDate},
+      {"myblock", CustomTags.CustomBrackedWrappedTag}
     ]
 end
 

--- a/test/support/custom_tags.ex
+++ b/test/support/custom_tags.ex
@@ -1,0 +1,67 @@
+defmodule CustomTags do
+  defmodule CurrentDate do
+    import NimbleParsec
+    alias Solid.Parser.Literal
+
+    @behaviour Solid.Tag.CustomTag
+
+    def spec() do
+      space = Literal.whitespace(min: 0)
+
+      ignore(string("{%"))
+      |> ignore(space)
+      |> ignore(string("get_current_date"))
+      |> ignore(space)
+      |> ignore(string("%}"))
+    end
+
+    def render(_context, _arguments) do
+      DateTime.utc_now().year |> to_string
+    end
+
+    def render(_context, _arguments, _options) do
+      DateTime.utc_now().year |> to_string
+    end
+  end
+
+  defmodule GetYearOfDate do
+    import NimbleParsec
+    alias Solid.Parser.{Literal, Argument}
+
+    @behaviour Solid.Tag.CustomTag
+
+    def spec() do
+      space = Literal.whitespace(min: 0)
+
+      ignore(string("{%"))
+      |> ignore(space)
+      |> ignore(string("get_year"))
+      |> ignore(space)
+      |> tag(Argument.arguments(), :arguments)
+      |> ignore(space)
+      |> ignore(string("%}"))
+    end
+
+    def render(_context, arguments: [value: dt_str]) do
+      {:ok, dt, _} = DateTime.from_iso8601(dt_str)
+      "#{dt.year}-#{dt.month}-#{dt.day}"
+    end
+
+    def render(context, arguments: [field: [var_name]]) do
+      dt_str = Map.fetch!(context.iteration_vars, var_name)
+      {:ok, dt, _} = DateTime.from_iso8601(dt_str)
+      "#{dt.year}-#{dt.month}-#{dt.day}"
+    end
+
+    def render(_context, [arguments: [value: dt_str]], _options) do
+      {:ok, dt, _} = DateTime.from_iso8601(dt_str)
+      "#{dt.year}-#{dt.month}-#{dt.day}"
+    end
+
+    def render(context, [arguments: [field: [var_name]]], _options) do
+      dt_str = Map.fetch!(context.iteration_vars, var_name)
+      {:ok, dt, _} = DateTime.from_iso8601(dt_str)
+      "#{dt.year}-#{dt.month}-#{dt.day}"
+    end
+  end
+end


### PR DESCRIPTION
## In this PR
Propose a flexible way to define custom tag

1. Move expression for field and arguments to helper modules
2. Define a `behaviour` for custom tag
3. Add test for custom tag using module

To implement new custom tag you need to create new module that implement `CustomTag` behaviour:

```elixir
defmodule MyCustomTag do
  import NimbleParsec
  @behaviour Solid.Tag.CustomTag

  @impl true
  def spec() do
    space = Solid.Parser.Literal.whitespace(min: 0)

    ignore(string("{%"))
    |> ignore(space)
    |> ignore(string("my_tag"))
    |> ignore(space)
    |> ignore(string("%}"))
  end

  @impl true
  def render(_context, _binding, _options) do
    [text: "my first tag"]
  end
end
```

- `spec` define how to parse your tag
- `render` define how to render your tag

Then add custom tag to your parser

```elixir
defmodule MyParser do
  use Solid.Parser.Base, custom_tag: [{"my_tag", MyCustomTag}]
end
```

Then pass your tag to render function

```elixir
"{% my_tag %}"
|> Solid.parse!(parser: MyParser)
|> Solid.render(tags: %{"my_tag" => MyCustomTag})
```
   