### PR TITLE
Allow custom filter module to be passed in through render option

### DIFF
--- a/lib/solid.ex
+++ b/lib/solid.ex
@@ -66,6 +66,8 @@ defmodule Solid do
   **Options**
   - `file_system`: a tuple of {FileSystemModule, options}. If this option is not specified, `Solid` uses `Solid.BlankFileSystem` which raises an error when the `render` tag is used. `Solid.LocalFileSystem` can be used or a custom module may be implemented. See `Solid.FileSystem` for more details.
 
+  - `custom_filters`: a module name where additional filters are defined. The base filters (thos from `Solid.Filter`) still can be used, however, custom filters always take precedence.
+
   **Example**:
 
   ```elixir

--- a/lib/solid/filter.ex
+++ b/lib/solid/filter.ex
@@ -14,7 +14,9 @@ defmodule Solid.Filter do
   1
   """
   def apply(filter, args, opts) do
-    custom_module = Application.get_env(:solid, :custom_filters, __MODULE__)
+    custom_module =
+      opts[:custom_filters] || Application.get_env(:solid, :custom_filters, __MODULE__)
+
     args_with_opts = args ++ [opts]
 
     cond do

--- a/test/integration/custom_filter_test.exs
+++ b/test/integration/custom_filter_test.exs
@@ -70,5 +70,14 @@ defmodule Solid.Integration.CustomFiltersTest do
       assert render(~s<{{ "app.css" | asset_url }}>, %{}, "app.css": "http://assets.example.com/") ==
                "http://assets.example.com/app.css"
     end
+
+    defmodule MyCustomFilters do
+      def add_one(x), do: x + 1
+    end
+
+    test "custom filters from render options" do
+      opts = [custom_filters: MyCustomFilters]
+      assert render("{{ number | add_one }}", %{"number" => 2}, opts) == "3"
+    end
   end
 end


### PR DESCRIPTION
When using this module in different parts of a codebase, one might
encounter the situation that a certain template needs a different set
of filters available than other templates.

The current approach of using application environment only allows for
a single custom filter module to be defined globally. This patch
changes that by creating a new option, `custom_filters:`, to be passed
in at render time.