### PR TITLE
Error context

### DIFF
--- a/lib/solid.ex
+++ b/lib/solid.ex
@@ -94,7 +94,9 @@ defmodule Solid do
   end
 
   def render(text, context = %Context{}, options) do
-    Solid.ErrorContext.new!()
+    unless options[:nested?] do
+      Solid.ErrorContext.new!()
+    end
 
     {result, context} =
       Enum.reduce(text, {[], context}, fn entry, {acc, context} ->
@@ -128,7 +130,7 @@ defmodule Solid do
     {result, context} = Tag.eval(tag, context, options)
 
     if result do
-      render(result, context, options)
+      render(result, context, Keyword.merge(options, nested?: true))
     else
       {"", context}
     end

--- a/lib/solid.ex
+++ b/lib/solid.ex
@@ -94,6 +94,8 @@ defmodule Solid do
   end
 
   def render(text, context = %Context{}, options) do
+    Solid.ErrorContext.new!()
+
     {result, context} =
       Enum.reduce(text, {[], context}, fn entry, {acc, context} ->
         try do

--- a/lib/solid/argument.ex
+++ b/lib/solid/argument.ex
@@ -31,12 +31,19 @@ defmodule Solid.Argument do
     scopes = Keyword.get(opts, :scopes, [:iteration_vars, :vars, :counter_vars])
     {filters, opts} = Keyword.pop(opts, :filters, [])
 
-    arg
-    |> do_get(context, scopes)
-    |> apply_filters(filters, context, opts)
+    value =
+      case do_get(arg, context, scopes) do
+        {:error, :not_found, key: key} ->
+          nil
+
+        {:ok, result} ->
+          result
+      end
+
+    apply_filters(value, filters, context, opts)
   end
 
-  defp do_get([value: val], _hash, _scopes), do: val
+  defp do_get([value: val], _hash, _scopes), do: {:ok, val}
 
   defp do_get([field: keys], context, scopes), do: Context.get_in(context, keys, scopes)
 

--- a/lib/solid/argument.ex
+++ b/lib/solid/argument.ex
@@ -34,6 +34,7 @@ defmodule Solid.Argument do
     value =
       case do_get(arg, context, scopes) do
         {:error, :not_found, key: key} ->
+          Solid.ErrorContext.add_undefined_variable(key)
           nil
 
         {:ok, result} ->

--- a/lib/solid/argument.ex
+++ b/lib/solid/argument.ex
@@ -34,7 +34,10 @@ defmodule Solid.Argument do
     value =
       case do_get(arg, context, scopes) do
         {:error, :not_found, key: key} ->
-          Solid.ErrorContext.add_undefined_variable(key)
+          if opts[:allow_undefined?] != true do
+            Solid.ErrorContext.add_undefined_variable(key)
+          end
+
           nil
 
         {:ok, result} ->

--- a/lib/solid/context.ex
+++ b/lib/solid/context.ex
@@ -14,17 +14,16 @@ defmodule Solid.Context do
 
   Possible scope values: :counter_vars, :vars or :iteration_vars
   """
-  @spec get_in(t(), [term()], [scope]) :: term
+  @spec get_in(t(), [term()], [scope]) :: {:ok, term} | {:error, :not_found, [key: [term()]]}
   def get_in(context, key, scopes) do
-    {:ok, result} =
-      scopes
-      |> Enum.map(&get_from_scope(context, &1, key))
-      |> Enum.find({:ok, nil}, fn
-        {:ok, _} -> true
-        _ -> false
-      end)
-
-    result
+    scopes
+    |> Enum.reverse()
+    |> Enum.map(&get_from_scope(context, &1, key))
+    |> Enum.reduce({:error, :not_found, key: key}, fn
+      {:ok, nil}, acc = {:ok, _} -> acc
+      value = {:ok, _}, _acc -> value
+      _value, acc -> acc
+    end)
   end
 
   @doc """
@@ -71,6 +70,7 @@ defmodule Solid.Context do
     do_get_in(context.iteration_vars, key)
   end
 
+  defp do_get_in(nil, []), do: {:ok, nil}
   defp do_get_in(nil, _), do: {:error, :not_found}
   defp do_get_in(data, []), do: {:ok, data}
 
@@ -87,11 +87,17 @@ defmodule Solid.Context do
   end
 
   defp do_get_in(data, [key | keys]) when is_map(data) do
-    do_get_in(data[key], keys)
+    case Map.fetch(data, key) do
+      {:ok, value} -> do_get_in(value, keys)
+      _ -> {:error, :not_found}
+    end
   end
 
   defp do_get_in(data, [key | keys]) when is_integer(key) and is_list(data) do
-    do_get_in(Enum.at(data, key), keys)
+    case Enum.fetch(data, key) do
+      {:ok, value} -> do_get_in(value, keys)
+      _ -> {:error, :not_found}
+    end
   end
 
   defp do_get_in(_, _), do: {:error, :not_found}

--- a/lib/solid/error_context.ex
+++ b/lib/solid/error_context.ex
@@ -1,0 +1,43 @@
+defmodule Solid.ErrorContext do
+  defmodule UndefinedVariable do
+    @enforce_keys [:variable]
+    defstruct @enforce_keys
+  end
+
+  defmodule UndefinedFilter do
+    @enforce_keys [:filter]
+    defstruct @enforce_keys
+  end
+
+  defstruct errors: []
+
+  @process_key Solid.ErrorContext
+
+  def new! do
+    Process.put(@process_key, %__MODULE__{})
+  end
+
+  def get do
+    Process.get(@process_key)
+  end
+
+  def add_undefined_variable(key) do
+    error = %UndefinedVariable{variable: Enum.join(key, ".")}
+    error_ctx = Process.get(@process_key)
+
+    if error_ctx do
+      error_ctx = %{error_ctx | errors: error_ctx.errors ++ [error]}
+      Process.put(@process_key, error_ctx)
+    end
+  end
+
+  def add_undefined_filter(filter) do
+    error = %UndefinedFilter{filter: filter}
+    error_ctx = Process.get(@process_key)
+
+    if error_ctx do
+      error_ctx = %{error_ctx | errors: error_ctx.errors ++ [error]}
+      Process.put(@process_key, error_ctx)
+    end
+  end
+end

--- a/lib/solid/filter.ex
+++ b/lib/solid/filter.ex
@@ -30,6 +30,7 @@ defmodule Solid.Filter do
         apply_filter({__MODULE__, filter, args})
 
       true ->
+        Solid.ErrorContext.add_undefined_filter(filter)
         List.first(args)
     end
   end

--- a/lib/solid/object.ex
+++ b/lib/solid/object.ex
@@ -12,6 +12,7 @@ defmodule Solid.Object do
     value = Argument.get(argument, context, [filters: object[:filters]] ++ options)
 
     stringify!(value)
+    |> warn_on_empty(argument: argument, filters: object[:filters])
   end
 
   defp stringify!(value) when is_list(value) do
@@ -25,4 +26,11 @@ defmodule Solid.Object do
   end
 
   defp stringify!(value), do: to_string(value)
+
+  defp warn_on_empty(value = "", argument: [field: key], filters: filters) do
+    Solid.ErrorContext.add_empty_warning(key, filters)
+    value
+  end
+
+  defp warn_on_empty(value, _opts), do: value
 end

--- a/lib/solid/tag/assign.ex
+++ b/lib/solid/tag/assign.ex
@@ -26,7 +26,7 @@ defmodule Solid.Tag.Assign do
         context,
         _options
       ) do
-    new_value = Solid.Argument.get(argument, context, filters: filters)
+    new_value = Solid.Argument.get(argument, context, filters: filters, allow_undefined?: true)
 
     context = %{context | vars: Map.put(context.vars, field_name, new_value)}
 

--- a/lib/solid/tag/capture.ex
+++ b/lib/solid/tag/capture.ex
@@ -25,7 +25,7 @@ defmodule Solid.Tag.Capture do
         context,
         options
       ) do
-    {captured, context} = Solid.render(result, context, options)
+    {captured, context} = Solid.render(result, context, Keyword.merge(options, nested?: true))
 
     context = %{
       context

--- a/lib/solid/tag/case.ex
+++ b/lib/solid/tag/case.ex
@@ -42,7 +42,10 @@ defmodule Solid.Tag.Case do
 
   @impl true
   def render([{:case_exp, field} | [{:whens, when_map} | _]] = tag, context, _options) do
-    result = when_map[Solid.Argument.get(field, context)]
+    result =
+      when_map[
+        Solid.Argument.get(field, context, allow_undefined?: Keyword.has_key?(tag, :else_exp))
+      ]
 
     if result do
       result

--- a/lib/solid/tag/counter.ex
+++ b/lib/solid/tag/counter.ex
@@ -26,7 +26,9 @@ defmodule Solid.Tag.Counter do
 
   @impl true
   def render([{operation, default}, field], context, _options) do
-    value = Argument.get([field], context, scopes: [:counter_vars]) || default
+    value =
+      Argument.get([field], context, scopes: [:counter_vars], allow_undefined?: true) || default
+
     {:field, [field_name]} = field
 
     context = %{

--- a/lib/solid/tag/for.ex
+++ b/lib/solid/tag/for.ex
@@ -93,7 +93,9 @@ defmodule Solid.Tag.For do
           |> maybe_put_forloop_map(enumerable_key, index, length)
 
         try do
-          {result, acc_context} = Solid.render(exp, acc_context, options)
+          {result, acc_context} =
+            Solid.render(exp, acc_context, Keyword.merge(options, nested?: true))
+
           acc_context = restore_initial_forloop_value(acc_context, acc_context_initial)
           {[result | acc_result], acc_context}
         catch

--- a/lib/solid/tag/render.ex
+++ b/lib/solid/tag/render.ex
@@ -30,7 +30,7 @@ defmodule Solid.Tag.Render do
         context,
         options
       ) do
-    template = Solid.Argument.get(template_binding, context)
+    template = Solid.Argument.get(template_binding, context, allow_undefined?: true)
 
     binding_vars =
       Keyword.get(argument_binding || [], :named_arguments, [])
@@ -42,7 +42,7 @@ defmodule Solid.Tag.Render do
 
     template_str = file_system.read_template_file(template, instance)
     template = Solid.parse!(template_str, options)
-    rendered_text = Solid.render(template, binding_vars, options)
+    rendered_text = Solid.render(template, binding_vars, Keyword.merge(options, nested?: true))
     {[text: rendered_text], context}
   end
 end

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -5,72 +5,87 @@ defmodule Solid.ContextTest do
   describe "get_in/3" do
     test "counter_vars scope only" do
       context = %Context{counter_vars: %{"x" => 1}}
-      assert Context.get_in(context, ["x"], [:counter_vars]) == 1
+      assert Context.get_in(context, ["x"], [:counter_vars]) == {:ok, 1}
     end
 
     test "vars scope only" do
       context = %Context{vars: %{"x" => 1}}
-      assert Context.get_in(context, ["x"], [:vars]) == 1
+      assert Context.get_in(context, ["x"], [:vars]) == {:ok, 1}
     end
 
     test "var scope with false value" do
       context = %Context{vars: %{"x" => false}}
-      assert Context.get_in(context, ["x"], [:vars]) == false
+      assert Context.get_in(context, ["x"], [:vars]) == {:ok, false}
     end
 
     test "var scope with nil value" do
       context = %Context{vars: %{"x" => nil}}
-      assert Context.get_in(context, ["x"], [:vars]) == nil
+      assert Context.get_in(context, ["x"], [:vars]) == {:ok, nil}
+    end
+
+    test "var scope missing value" do
+      context = %Context{vars: %{}}
+      assert Context.get_in(context, ["x"], [:vars]) == {:error, :not_found, key: ["x"]}
     end
 
     test "iteration_vars scope only" do
       context = %Context{iteration_vars: %{"x" => 1}}
-      assert Context.get_in(context, ["x"], [:iteration_vars]) == 1
+      assert Context.get_in(context, ["x"], [:iteration_vars]) == {:ok, 1}
     end
 
     test "nested access" do
       context = %Context{vars: %{"x" => %{"y" => 1}}}
-      assert Context.get_in(context, ["x", "y"], [:vars]) == 1
+      assert Context.get_in(context, ["x", "y"], [:vars]) == {:ok, 1}
     end
 
     test "nested access string" do
       context = %Context{vars: %{"x" => "y"}}
-      assert Context.get_in(context, ["x", "y"], [:vars]) == nil
+      assert Context.get_in(context, ["x", "y"], [:vars]) == {:error, :not_found, key: ["x", "y"]}
     end
 
     test "nested access nil" do
       context = %Context{vars: %{"x" => 1}}
-      assert Context.get_in(context, ["x", "y"], [:vars]) == nil
+      assert Context.get_in(context, ["x", "y"], [:vars]) == {:error, :not_found, key: ["x", "y"]}
+    end
+
+    test "nested access missing" do
+      context = %Context{vars: %{}}
+      assert Context.get_in(context, ["x", "y"], [:vars]) == {:error, :not_found, key: ["x", "y"]}
     end
 
     test "counter_vars & vars scopes with both keys existing" do
       context = %Context{vars: %{"x" => 1}, counter_vars: %{"x" => 2}}
-      assert Context.get_in(context, ["x"], [:vars, :counter_vars]) == 1
+      assert Context.get_in(context, ["x"], [:vars, :counter_vars]) == {:ok, 1}
     end
 
     test "counter_vars & vars scopes with counter_vars key existing" do
       context = %Context{counter_vars: %{"x" => 2}}
-      assert Context.get_in(context, ["x"], [:vars, :counter_vars]) == 2
+      assert Context.get_in(context, ["x"], [:vars, :counter_vars]) == {:ok, 2}
     end
 
     test "list access" do
       context = %Context{vars: %{"x" => ["a", "b", "c"]}}
-      assert Context.get_in(context, ["x", 1], [:vars]) == "b"
+      assert Context.get_in(context, ["x", 1], [:vars]) == {:ok, "b"}
+    end
+
+    test "list invalid index" do
+      context = %Context{vars: %{"x" => ["a", "b", "c"]}}
+      assert Context.get_in(context, ["x", 3], [:vars]) == {:error, :not_found, key: ["x", 3]}
     end
 
     test "list size" do
       context = %Context{vars: %{"x" => ["a", "b", "c"]}}
-      assert Context.get_in(context, ["x", "size"], [:vars]) == 3
+      assert Context.get_in(context, ["x", "size"], [:vars]) == {:ok, 3}
     end
 
     test "map size" do
       context = %Context{vars: %{"x" => %{"a" => 1, "b" => 2}}}
-      assert Context.get_in(context, ["x", "size"], [:vars]) == 2
+      assert Context.get_in(context, ["x", "size"], [:vars]) == {:ok, 2}
     end
 
     test "map size key" do
       context = %Context{vars: %{"x" => %{"a" => 1, "b" => 2, "size" => 42}}}
-      assert Context.get_in(context, ["x", "size"], [:vars]) == 42
+      assert Context.get_in(context, ["x", "size"], [:vars]) == {:ok, 42}
     end
   end
 

--- a/test/integration/custom_filter_test.exs
+++ b/test/integration/custom_filter_test.exs
@@ -38,25 +38,33 @@ defmodule Solid.Integration.CustomFiltersTest do
   describe "custom filters" do
     test "date year filter", %{date: date} do
       assert render("{{ date_var | date_year }}", %{"date_var" => date}) == "2019"
+      assert_no_errors!()
     end
 
     test "date format m/d/yyyy", %{date: date} do
       assert render(~s<{{ date_var | date_format: "m/d/yyyy" }}>, %{"date_var" => date}) ==
                "10/31/2019"
+
+      assert_no_errors!()
     end
 
     test "date format d.m.yyyy", %{date: date} do
       assert render(~s<{{ date_var | date_format: "d.m.yyyy" }}>, %{"date_var" => date}) ==
                "31.10.2019"
+
+      assert_no_errors!()
     end
 
     test "date format with malformed format", %{date: date} do
       assert render(~s<{{ date_var | date_format: "x/y/z" }}>, %{"date_var" => date}) ==
                "2019-10-31"
+
+      assert_no_errors!()
     end
 
     test "substitute without bindings" do
       assert render(~s<{{ "hello world" | substitute }}>)
+      assert_no_errors!()
     end
 
     test "substitute with bindings", %{date: date} do
@@ -64,11 +72,15 @@ defmodule Solid.Integration.CustomFiltersTest do
                "date_var" => date
              }) ==
                "today is 2019-10-31"
+
+      assert_no_errors!()
     end
 
     test "asset_url with opts" do
       assert render(~s<{{ "app.css" | asset_url }}>, %{}, "app.css": "http://assets.example.com/") ==
                "http://assets.example.com/app.css"
+
+      assert_no_errors!()
     end
 
     defmodule MyCustomFilters do

--- a/test/integration/custom_tag_test.exs
+++ b/test/integration/custom_tag_test.exs
@@ -6,11 +6,15 @@ defmodule Solid.Integration.CustomTagsTest do
     test "pass in custom tag that needs no arguments" do
       assert render("{% get_current_date %}", %{}, parser: CustomDateParser) ==
                to_string(DateTime.utc_now().year)
+
+      assert_no_errors!()
     end
 
     test "pass in custom tag that needs arguments" do
       assert render(~s({% get_year "2020-08-06T06:23:48Z" %}), %{}, parser: CustomDateParser) ==
                "2020-8-6"
+
+      assert_no_errors!()
     end
 
     test "custom tags are evaluated inside of for loops" do
@@ -19,6 +23,8 @@ defmodule Solid.Integration.CustomTagsTest do
                %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
                parser: CustomDateParser
              ) == "<span>2020-8-6</span><span>2021-5-3</span>"
+
+      assert_no_errors!()
     end
 
     test "custom tags are evaluated inside of captures" do
@@ -27,6 +33,8 @@ defmodule Solid.Integration.CustomTagsTest do
                %{"dates" => ["2020-08-06T06:23:48Z", "2021-05-03T06:23:48Z"]},
                parser: CustomDateParser
              ) == "2020-8-6"
+
+      assert_no_errors!()
     end
 
     test "custom tags are evaluated inside of for loops and captures" do
@@ -44,6 +52,7 @@ defmodule Solid.Integration.CustomTagsTest do
         )
 
       assert String.trim(rendered) == "<span>2020-8-6</span><span>2021-5-3</span>"
+      assert_no_errors!()
     end
 
     test "custom block wrap bracket" do
@@ -59,6 +68,7 @@ defmodule Solid.Integration.CustomTagsTest do
         )
 
       assert String.trim(rendered) == "[[hello]]"
+      assert_no_errors!()
     end
   end
 end

--- a/test/integration/filters_test.exs
+++ b/test/integration/filters_test.exs
@@ -4,34 +4,57 @@ defmodule Solid.Integration.FiltersTest do
 
   test "multiple filters" do
     assert render("Text {{ key | default: 1 | upcase }} !", %{"key" => "abc"}) == "Text ABC !"
+    assert_no_errors!()
   end
 
   test "upcase filter" do
     assert render("Text {{ key | upcase }} !", %{"key" => "abc"}) == "Text ABC !"
+    assert_no_errors!()
   end
 
   test "default filter with default integer" do
     assert render("Number {{ key | default: 456 }} !") == "Number 456 !"
+
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+             errors: [
+               %Solid.ErrorContext.UndefinedVariable{variable: "key"}
+             ]
+           }
   end
 
   test "default filter with default string" do
     assert render("Number {{ key | default: \"456\" }} !", %{}) == "Number 456 !"
+
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+             errors: [
+               %Solid.ErrorContext.UndefinedVariable{variable: "key"}
+             ]
+           }
   end
 
   test "default filter with default float" do
     assert render("Number {{ key | default: 44.5 }} !", %{}) == "Number 44.5 !"
+
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+             errors: [
+               %Solid.ErrorContext.UndefinedVariable{variable: "key"}
+             ]
+           }
   end
 
   test "default filter with nil" do
     assert render("Number {{ nil | default: 456 }} !", %{"nil" => 123}) == "Number 456 !"
+    assert_no_errors!()
   end
 
   test "default filter with an integer" do
     assert render("Number {{ 123 | default: 456 }} !", %{}) == "Number 123 !"
+    assert_no_errors!()
   end
 
   test "default filter with a negative integer" do
     assert render("Number {{ 123 | plus: -123}} !", %{}) == "Number 0 !"
+    assert_no_errors!()
   end
 
   test "replace" do
@@ -40,6 +63,8 @@ defmodule Solid.Integration.FiltersTest do
              %{}
            ) ==
              "Take your protein pills and put your helmet on"
+
+    assert_no_errors!()
   end
 
   test "concat" do
@@ -54,6 +79,8 @@ defmodule Solid.Integration.FiltersTest do
              """,
              %{}
            ) == "\n\n\n\n- apples\n\n- oranges\n\n- kale\n\n- cucumbers\n\n"
+
+    assert_no_errors!()
   end
 
   test "invalid filter applied" do
@@ -74,6 +101,28 @@ defmodule Solid.Integration.FiltersTest do
              errors: [
                %Solid.ErrorContext.UndefinedFilter{filter: "invalid"},
                %Solid.ErrorContext.UndefinedFilter{filter: "another"}
+             ]
+           }
+  end
+
+  test "blank value after filters applied" do
+    assert render("{{ key | upcase }}", %{"key" => ""}) == ""
+
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+             errors: [],
+             warnings: [
+               %Solid.ErrorContext.EmptyWarning{filter: ["upcase"], variable: "key"}
+             ]
+           }
+
+    assert render("{{ key | upcase | default: '' }}", %{}) == ""
+
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+             errors: [
+               %Solid.ErrorContext.UndefinedVariable{variable: "key"}
+             ],
+             warnings: [
+               %Solid.ErrorContext.EmptyWarning{filter: ["upcase", "default"], variable: "key"}
              ]
            }
   end

--- a/test/integration/filters_test.exs
+++ b/test/integration/filters_test.exs
@@ -61,18 +61,20 @@ defmodule Solid.Integration.FiltersTest do
     assert Solid.ErrorContext.get() == %Solid.ErrorContext{}
 
     assert render("{{ key | invalid }}", %{"key" => "abc"}) == "abc"
+
     assert Solid.ErrorContext.get() == %Solid.ErrorContext{
-      errors: [
-        %Solid.ErrorContext.UndefinedFilter{filter: "invalid"}
-      ]
-    }
+             errors: [
+               %Solid.ErrorContext.UndefinedFilter{filter: "invalid"}
+             ]
+           }
 
     assert render("{{ key | upcase | invalid | another }}", %{"key" => "abc"}) == "ABC"
+
     assert Solid.ErrorContext.get() == %Solid.ErrorContext{
-      errors: [
-        %Solid.ErrorContext.UndefinedFilter{filter: "invalid"},
-        %Solid.ErrorContext.UndefinedFilter{filter: "another"}
-      ]
-    }
+             errors: [
+               %Solid.ErrorContext.UndefinedFilter{filter: "invalid"},
+               %Solid.ErrorContext.UndefinedFilter{filter: "another"}
+             ]
+           }
   end
 end

--- a/test/integration/filters_test.exs
+++ b/test/integration/filters_test.exs
@@ -55,4 +55,24 @@ defmodule Solid.Integration.FiltersTest do
              %{}
            ) == "\n\n\n\n- apples\n\n- oranges\n\n- kale\n\n- cucumbers\n\n"
   end
+
+  test "invalid filter applied" do
+    assert render("{{ key | upcase }}", %{"key" => "abc"}) == "ABC"
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{}
+
+    assert render("{{ key | invalid }}", %{"key" => "abc"}) == "abc"
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+      errors: [
+        %Solid.ErrorContext.UndefinedFilter{filter: "invalid"}
+      ]
+    }
+
+    assert render("{{ key | upcase | invalid | another }}", %{"key" => "abc"}) == "ABC"
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+      errors: [
+        %Solid.ErrorContext.UndefinedFilter{filter: "invalid"},
+        %Solid.ErrorContext.UndefinedFilter{filter: "another"}
+      ]
+    }
+  end
 end

--- a/test/integration/objects_test.exs
+++ b/test/integration/objects_test.exs
@@ -4,32 +4,40 @@ defmodule Solid.Integration.ObjectsTest do
 
   test "no liquid template" do
     assert render("No Number!", %{"key" => 123}) == "No Number!"
+    assert_no_errors!()
   end
 
   test "single quoted string" do
     assert render("String: {{ 'text' }}") == "String: text"
+    assert_no_errors!()
   end
 
   test "double quoted string" do
     assert render("String: {{ \"text\" }}") == "String: text"
+    assert_no_errors!()
   end
 
   test "basic key rendering" do
     assert render("Number {{ key }} ! {{ key }}", %{"key" => 123}) == "Number 123 ! 123"
+    assert_no_errors!()
   end
 
   test "key rendering with list" do
     assert render("Number {{ key }} ! {{ key }}", %{"key" => [1, [2, "three"]]}) ==
              "Number 12three ! 12three"
+
+    assert_no_errors!()
   end
 
   test "field with access" do
     assert render("Number {{ key[1] }}", %{"key" => [1, 2, 3]}) == "Number 2"
+    assert_no_errors!()
   end
 
   test "complex key rendering" do
     hash = %{"key1" => %{"key2" => %{"key3" => 123}}}
     assert render("Number {{ key1.key2.key3 }} !", hash) == "Number 123 !"
+    assert_no_errors!()
   end
 
   test "whitespace control" do
@@ -47,6 +55,8 @@ defmodule Solid.Integration.ObjectsTest do
 
            :Hans!
            """
+
+    assert_no_errors!()
   end
 
   test "missing variables" do
@@ -61,6 +71,31 @@ defmodule Solid.Integration.ObjectsTest do
                %Solid.ErrorContext.UndefinedVariable{variable: "key"},
                %Solid.ErrorContext.UndefinedVariable{variable: "key.value"},
                %Solid.ErrorContext.UndefinedVariable{variable: "list.1"}
+             ],
+             warnings: [
+               %Solid.ErrorContext.EmptyWarning{filter: [], variable: "key"},
+               %Solid.ErrorContext.EmptyWarning{filter: [], variable: "key.value"},
+               %Solid.ErrorContext.EmptyWarning{filter: [], variable: "list.1"}
+             ]
+           }
+  end
+
+  test "blank variables" do
+    assert render("Number {{ key }}", %{"key" => ""}) == "Number "
+
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+             errors: [],
+             warnings: [
+               %Solid.ErrorContext.EmptyWarning{filter: [], variable: "key"}
+             ]
+           }
+
+    assert render("Number {{ key }}", %{"key" => nil}) == "Number "
+
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+             errors: [],
+             warnings: [
+               %Solid.ErrorContext.EmptyWarning{filter: [], variable: "key"}
              ]
            }
   end

--- a/test/integration/objects_test.exs
+++ b/test/integration/objects_test.exs
@@ -48,4 +48,18 @@ defmodule Solid.Integration.ObjectsTest do
            :Hans!
            """
   end
+
+  test "missing variables" do
+    assert render("Number {{ key }}", %{"key" => 1}) == "Number 1"
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{}
+
+    assert render("Number {{ key }} ! {{ key.value }} ! {{list[0]}} {{list[1]}}", %{"list" => [1]}) == "Number  !  ! 1 "
+    assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+      errors: [
+        %Solid.ErrorContext.UndefinedVariable{variable: "key"},
+        %Solid.ErrorContext.UndefinedVariable{variable: "key.value"},
+        %Solid.ErrorContext.UndefinedVariable{variable: "list.1"}
+      ]
+    }
+  end
 end

--- a/test/integration/objects_test.exs
+++ b/test/integration/objects_test.exs
@@ -53,13 +53,15 @@ defmodule Solid.Integration.ObjectsTest do
     assert render("Number {{ key }}", %{"key" => 1}) == "Number 1"
     assert Solid.ErrorContext.get() == %Solid.ErrorContext{}
 
-    assert render("Number {{ key }} ! {{ key.value }} ! {{list[0]}} {{list[1]}}", %{"list" => [1]}) == "Number  !  ! 1 "
+    assert render("Number {{ key }} ! {{ key.value }} ! {{list[0]}} {{list[1]}}", %{"list" => [1]}) ==
+             "Number  !  ! 1 "
+
     assert Solid.ErrorContext.get() == %Solid.ErrorContext{
-      errors: [
-        %Solid.ErrorContext.UndefinedVariable{variable: "key"},
-        %Solid.ErrorContext.UndefinedVariable{variable: "key.value"},
-        %Solid.ErrorContext.UndefinedVariable{variable: "list.1"}
-      ]
-    }
+             errors: [
+               %Solid.ErrorContext.UndefinedVariable{variable: "key"},
+               %Solid.ErrorContext.UndefinedVariable{variable: "key.value"},
+               %Solid.ErrorContext.UndefinedVariable{variable: "list.1"}
+             ]
+           }
   end
 end

--- a/test/integration/tags_test.exs
+++ b/test/integration/tags_test.exs
@@ -5,66 +5,86 @@ defmodule Solid.Integration.TagsTest do
   describe "if" do
     test "true expression" do
       assert render("{% if 1 == 1 %}True{% endif %} is True", %{"key" => 123}) == "True is True"
+      assert_no_errors!()
     end
 
     test "false expression" do
       assert render("{% if 1 != 1 %}True{% endif %}False?", %{"key" => 123}) == "False?"
+      assert_no_errors!()
     end
 
     test "true" do
       assert render("{% if true %}True{% endif %} is True", %{"key" => 123}) == "True is True"
+      assert_no_errors!()
     end
 
     test "false" do
       assert render("{% if false %}True{% endif %}False?", %{"key" => 123}) == "False?"
+      assert_no_errors!()
     end
 
     test "boolean expression" do
       assert render("{% if 1 != 1 or 3 == 3 %}True{% endif %}", %{"key" => 123}) == "True"
+      assert_no_errors!()
     end
 
     test "nested" do
       assert render("{% if 1 == 1 %}{% if 1 != 2 %}True{% endif %}{% endif %} is True", %{
                "key" => 123
              }) == "True is True"
+
+      assert_no_errors!()
     end
 
     test "with object" do
       assert render("{% if 1 != 2 %}{{ key }}{% endif %}", %{"key" => 123}) == "123"
+
+      assert_no_errors!()
     end
 
     test "else true" do
       assert render("{% if 1 == 1 %}True{% else %}False{% endif %} is True", %{"key" => 123}) ==
                "True is True"
+
+      assert_no_errors!()
     end
 
     test "else false" do
       assert render("{% if 1 != 1 %}True{% else %}False{% endif %} is False", %{"key" => 123}) ==
                "False is False"
+
+      assert_no_errors!()
     end
 
     test "elsif" do
       assert render("{% if 1 != 1 %}if{% elsif 1 == 1 %}elsif{% endif %}") == "elsif"
+      assert_no_errors!()
     end
   end
 
   describe "unless" do
     test "true expression" do
       assert render("{% unless 1 == 1 %}True{% endunless %}False?", %{"key" => 123}) == "False?"
+      assert_no_errors!()
     end
 
     test "false expression" do
       assert render("{% unless 1 != 1 %}True{% endunless %} is True", %{"key" => 123}) ==
                "True is True"
+
+      assert_no_errors!()
     end
 
     test "true" do
       assert render("{% unless true %}False{% endunless %}False?", %{"key" => 123}) == "False?"
+      assert_no_errors!()
     end
 
     test "false" do
       assert render("{% unless false %}True{% endunless %} is True", %{"key" => 123}) ==
                "True is True"
+
+      assert_no_errors!()
     end
 
     test "nested" do
@@ -72,14 +92,18 @@ defmodule Solid.Integration.TagsTest do
                "{% unless 1 != 1 %}{% unless 1 == 2 %}True{% endunless %}{% endunless %} is True",
                %{"key" => 123}
              ) == "True is True"
+
+      assert_no_errors!()
     end
 
     test "with object" do
       assert render("{% unless 1 == 2 %}{{ key }}{% endunless %}", %{"key" => 123}) == "123"
+      assert_no_errors!()
     end
 
     test "elsif" do
       assert render("{% unless 1 == 1 %}unless{% elsif 1 == 1 %}elsif{% endunless %}") == "elsif"
+      assert_no_errors!()
     end
   end
 
@@ -93,6 +117,13 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text) == "\n"
+
+      assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+               errors: [
+                 %Solid.ErrorContext.UndefinedVariable{variable: "handle"}
+               ],
+               warnings: []
+             }
     end
 
     test "no matching when with else" do
@@ -106,6 +137,7 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text) == "\nElse\n\n"
+      assert_no_errors!()
     end
 
     test "with a matching when" do
@@ -119,6 +151,7 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text, %{"handle" => "cake"}) == "\nThis is a cake\n\n"
+      assert_no_errors!()
     end
   end
 
@@ -131,6 +164,7 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text, %{"values" => [1, 2]}) == "\n  Got: 1\n\n  Got: 2\n\n"
+      assert_no_errors!()
     end
 
     test "for using range literals" do
@@ -141,6 +175,7 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text, %{}) == "\n  Got: 1\n\n  Got: 2\n\n"
+      assert_no_errors!()
     end
 
     test "for using range variables" do
@@ -151,6 +186,7 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text, %{"first" => 1, "last" => 2}) == "\n  Got: 1\n\n  Got: 2\n\n"
+      assert_no_errors!()
     end
 
     test "simple for with a break" do
@@ -161,6 +197,7 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text, %{"values" => [1, 2]}) == "\n Got: 1\n\n\n"
+      assert_no_errors!()
     end
 
     test "with conditional tag" do
@@ -171,11 +208,19 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text, %{"values" => [1, 2, 3]}) == "\n  \n\n  \n\n  I got 3!\n\n"
+      assert_no_errors!()
     end
 
     test "with no value" do
       text = "test {% for value in values %}{{ value }}{% endfor %}"
       assert render(text, %{}) == "test "
+
+      assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+               errors: [
+                 %Solid.ErrorContext.UndefinedVariable{variable: "values"}
+               ],
+               warnings: []
+             }
     end
 
     test "with no value and an else" do
@@ -187,7 +232,27 @@ defmodule Solid.Integration.TagsTest do
       {% endfor %}
       """
 
+      assert render(text, %{"values" => []}) == "test \nelse\n\n"
+      assert_no_errors!()
+    end
+
+    test "with no variable and an else" do
+      text = """
+      test {% for value in values %}
+        {{ value }}
+      {% else %}
+      else
+      {% endfor %}
+      """
+
       assert render(text, %{}) == "test \nelse\n\n"
+
+      assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+               errors: [
+                 %Solid.ErrorContext.UndefinedVariable{variable: "values"}
+               ],
+               warnings: []
+             }
     end
   end
 
@@ -199,6 +264,23 @@ defmodule Solid.Integration.TagsTest do
       """
 
       assert render(text, %{}) == "\nVariable: 1\n"
+      assert_no_errors!()
+    end
+
+    test "assign to empty" do
+      text = """
+      {% assign variable = "" %}
+      Variable: {{ variable }}
+      """
+
+      assert render(text, %{"variable" => 1}) == "\nVariable: \n"
+
+      assert Solid.ErrorContext.get() == %Solid.ErrorContext{
+               errors: [],
+               warnings: [
+                 %Solid.ErrorContext.EmptyWarning{filter: [], variable: "variable"}
+               ]
+             }
     end
 
     test "assign existing variable" do
@@ -211,6 +293,8 @@ defmodule Solid.Integration.TagsTest do
 
              Variable: 123
              """
+
+      assert_no_errors!()
     end
   end
 
@@ -225,6 +309,8 @@ defmodule Solid.Integration.TagsTest do
              0
              counter value: 1
              """
+
+      assert_no_errors!()
     end
 
     test "increment multiple calls" do
@@ -239,6 +325,8 @@ defmodule Solid.Integration.TagsTest do
              1
              counter value: 2
              """
+
+      assert_no_errors!()
     end
   end
 
@@ -253,6 +341,8 @@ defmodule Solid.Integration.TagsTest do
              -1
              counter value: -2
              """
+
+      assert_no_errors!()
     end
 
     test "decrement multiple calls" do
@@ -267,6 +357,8 @@ defmodule Solid.Integration.TagsTest do
              -2
              counter value: -3
              """
+
+      assert_no_errors!()
     end
   end
 
@@ -289,6 +381,8 @@ defmodule Solid.Integration.TagsTest do
              the text is here
 
              """
+
+      assert_no_errors!()
     end
   end
 
@@ -303,6 +397,8 @@ defmodule Solid.Integration.TagsTest do
       assert render(text, %{}) == """
              pre-break
              """
+
+      assert_no_errors!()
     end
   end
 
@@ -315,6 +411,8 @@ defmodule Solid.Integration.TagsTest do
       assert render(text, %{}) == """
              {{ 5 | plus: 6 }} equals 11
              """
+
+      assert_no_errors!()
     end
 
     test "raw with nested tag" do
@@ -327,6 +425,8 @@ defmodule Solid.Integration.TagsTest do
              {% increment counter %}{{ counter }}
              0 1
              """
+
+      assert_no_errors!()
     end
   end
 
@@ -340,6 +440,8 @@ defmodule Solid.Integration.TagsTest do
                """
                barbaz
                """
+
+      assert_no_errors!()
     end
 
     test "with an argument" do
@@ -351,6 +453,8 @@ defmodule Solid.Integration.TagsTest do
                """
                barbaz-show-me
                """
+
+      assert_no_errors!()
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -64,4 +64,10 @@ defmodule Solid.Helpers do
       end
     end
   end
+
+  defmacro assert_no_errors! do
+    quote do
+      assert Solid.ErrorContext.get() == %Solid.ErrorContext{}
+    end
+  end
 end


### PR DESCRIPTION
This is just a prototype of capturing errors, but I wanted to at least attempt it given that I made an issue (#101)

I think I may test this out on my own app, but I really don't like the process dictionary approach. I did it this way because I *think* that propagating errors for all Argument / Filter cases would require a ton of code change.

In particular, `Solid.Argument.get` is called in various tags and expression handling. Filter application is easier because it's only called in one place.

Edit: I also added "empty value" detection, which is also important for my use case. I'm not sure if this is included in Liquid at all, but it seems like a useful thing to detect.