### PR TITLE
Allow standard tags to be removed from the parser

### DIFF
--- a/lib/solid/parser/base.ex
+++ b/lib/solid/parser/base.ex
@@ -1,8 +1,10 @@
 defmodule Solid.Parser.Base do
   defmacro __using__(opts) do
     custom_tag_modules = Keyword.get(opts, :custom_tags, [])
+    excluded_tags = Keyword.get(opts, :excluded_tags, [])
 
-    quote location: :keep, bind_quoted: [custom_tag_modules: custom_tag_modules] do
+    quote location: :keep,
+          bind_quoted: [custom_tag_modules: custom_tag_modules, excluded_tags: excluded_tags] do
       import NimbleParsec
       alias Solid.Parser.{Literal, Variable, Argument, BaseTag}
 
@@ -49,6 +51,7 @@ defmodule Solid.Parser.Base do
           Solid.Tag.Cycle,
           Solid.Tag.Render
         ]
+        |> Enum.reject(&(&1 in excluded_tags))
         |> Enum.map(fn tag ->
           tag(tag.spec(__MODULE__), tag)
         end)

--- a/test/integration/tags_test.exs
+++ b/test/integration/tags_test.exs
@@ -353,4 +353,18 @@ defmodule Solid.Integration.TagsTest do
                """
     end
   end
+
+  describe "excluded standard tag" do
+    test "a standard tag can be removed from the parser" do
+      text = """
+      {% render "nope" %}
+      """
+
+      assert render(text, %{}) ==
+               "%File.Error{action: \"\", path: nil, reason: \"This solid context does not allow includes.\"}"
+
+      assert render(text, %{}, parser: NoRenderParser) ==
+               "%Solid.TemplateError{line: {1, 0}, message: \"Reason: expected end of string, line: 1\", reason: \"expected end of string\"}"
+    end
+  end
 end

--- a/test/support/custom_parsers.ex
+++ b/test/support/custom_parsers.ex
@@ -11,3 +11,7 @@ defmodule CustomFooParser do
   use Solid.Parser.Base,
     custom_tags: [CustomTags.FoobarTag, CustomTags.FoobarValTag]
 end
+
+defmodule NoRenderParser do
+  use Solid.Parser.Base, excluded_tags: [Solid.Tag.Render]
+end


### PR DESCRIPTION
This allows custom filters like "render" to be implemented using custom tags instead of the built-in ones.

I'm not sure if this is something you want, but I found myself in a situation where I cannot upgrade solid without breaking changes due to the implementation of render being different than my own (I share context while the built-in does not). So, I figure I'd PR it back at least.