### PR TITLE
Allow hyphens in template names

### DIFF
--- a/lib/solid/file_system.ex
+++ b/lib/solid/file_system.ex
@@ -83,7 +83,7 @@ defmodule Solid.LocalFileSystem do
   end
 
   def full_path(template_path, file_system) do
-    if String.match?(template_path, Regex.compile!("^[^./][a-zA-Z0-9_/]+$")) do
+    if String.match?(template_path, Regex.compile!("^[^./][a-zA-Z0-9_/-]+$")) do
       template_name = String.replace(file_system.pattern, "%s", Path.basename(template_path))
 
       full_path =


### PR DESCRIPTION
Hey there, I think it’s a bit unexpected that hyphens are not accepted in template names. It took me quite a while until I had figured out what was going on 😅