### PR TITLE
Allow usage of both args and opts to filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,27 @@ opts = [custom_filters: MyCustomFilters, host: "http://example.com"]
 
 "{{ file_path | asset_url }}"
 |> Solid.parse!()
-|> Solid.render(%{ "file_path" => "/styles/app.css"}, opts)
+|> Solid.render!(%{ "file_path" => "/styles/app.css"}, opts)
 |> IO.puts()
 # http://example.com/styles/app.css
+```
+
+If you also want to pass arguments to your custom filter, they are provided as a map in the second argument to the filter function:
+
+```
+defmodule MyCustomFilters do
+  def asset_url(path, %{"version" => version, "case" => case} = _args, opts) do
+    opts[:host] <> path <> "?v=" <> to_string(version) <> "&case=" <> case
+  end
+end
+
+opts = [custom_filters: MyCustomFilters, host: "http://example.com"]
+
+"{{ file_path | asset_url: version: 1, case: 'closed' }}"
+|> Solid.parse!()
+|> Solid.render!(%{ "file_path" => "/styles/app.css"}, opts)
+|> IO.puts()
+# http://example.com/styles/app.css?v=1&case=closed
 ```
 
 ## Strict rendering

--- a/lib/solid/argument.ex
+++ b/lib/solid/argument.ex
@@ -48,7 +48,7 @@ defmodule Solid.Argument do
 
     {result, context} =
       filter
-      |> Filter.apply([input | values], opts)
+      |> Filter.apply(input, values, opts)
       |> case do
         {:error, exception, value} ->
           {value, Context.put_errors(context, exception)}
@@ -70,7 +70,7 @@ defmodule Solid.Argument do
 
     {result, context} =
       filter
-      |> Filter.apply([input | Enum.reverse(values)], opts)
+      |> Filter.apply(input, Enum.reverse(values), opts)
       |> case do
         {:error, exception, value} ->
           {value, Context.put_errors(context, exception)}

--- a/lib/solid/filter.ex
+++ b/lib/solid/filter.ex
@@ -58,7 +58,6 @@ defmodule Solid.Filter do
   defp filter_exists?({module, function, arity}) do
     try do
       function = String.to_existing_atom(function)
-      Code.ensure_loaded(module)
       function_exported?(module, function, arity)
     rescue
       ArgumentError -> false


### PR DESCRIPTION
Currently there is a problem when trying to use custom filter with both options and arguments. So executing following code:
```
defmodule MyCustomFilters do
  def asset_url(path, %{"version" => version, "case" => case} = _args, opts) do
    opts[:host] <> path <> "?v=" <> to_string(version) <> "&case=" <> case
  end
end

opts = [custom_filters: MyCustomFilters, host: "http://example.com"]

"{{ file_path | asset_url: version: 1, case: 'closed' }}"
|> Solid.parse!()
|> Solid.render!(%{ "file_path" => "/styles/app.css"}, opts)
|> IO.puts()
```

would fail.

This PR fixes that, refactoring a little bit custom filter calls and adding support for passing arguments and options as separate arguments to filters.

So given code works:
```
defmodule MyCustomFilters do
  def asset_url(path, %{"version" => version, "case" => case} = _args, opts) do
    opts[:host] <> path <> "?v=" <> to_string(version) <> "&case=" <> case
  end
end

opts = [custom_filters: MyCustomFilters, host: "http://example.com"]

"{{ file_path | asset_url: version: 1, case: 'closed' }}"
|> Solid.parse!()
|> Solid.render!(%{ "file_path" => "/styles/app.css"}, opts)
|> IO.puts()
# http://example.com/styles/app.css?v=1&case=closed
```

on sidenote it also adds support for ensuring that custom filter code is loaded.

Please note there isn't single change in existing tests, since it's all backward compatible.