### PR TITLE
Update default filter to return fallback value for empty strings

### DIFF
--- a/lib/solid/filter.ex
+++ b/lib/solid/filter.ex
@@ -179,11 +179,15 @@ defmodule Solid.Filter do
 
   iex> Solid.Filter.default([], 456)
   456
+
+  iex> Solid.Filter.default("", 456)
+  456
   """
   @spec default(any, any) :: any
   def default(nil, value), do: value
   def default(false, value), do: value
   def default([], value), do: value
+  def default("", value), do: value
   def default(input, _), do: input
 
   @doc """

--- a/test/cases/134/input.json
+++ b/test/cases/134/input.json
@@ -1,0 +1,6 @@
+{
+  "var_nil": null,
+  "var_false": false,
+  "var_empty_array": [],
+  "var_empty_string": ""
+}

--- a/test/cases/134/input.liquid
+++ b/test/cases/134/input.liquid
@@ -1,0 +1,5 @@
+{{ var_nil | default: "nil" }}
+{{ var_false | default: "false" }}
+{{ var_empty_array | default: "empty array" }}
+{{ var_empty_string | default: "empty string" }}
+


### PR DESCRIPTION
Hey there 👋 

This updates the `default` filter to return the fallback value for empty strings according to [spec](https://shopify.github.io/liquid/filters/default/).

Liquid:
```
$ echo 'Hello {{ name | default: "there" }}!' | liquid '{ "name": "" }'
Hello there!
```

Solid:
```
iex > "Hello {{ name | default: \"there\" }}!" |> Solid.parse!() |> Solid.render!(%{"name" => ""}) |> IO.puts()
Hello !
```