### PR TITLE
Conditionally omit built-in matcher implementations

### DIFF
--- a/lib/solid/matcher.ex
+++ b/lib/solid/matcher.ex
@@ -4,74 +4,104 @@ defprotocol Solid.Matcher do
   def match(_, _)
 end
 
-defimpl Solid.Matcher, for: Any do
-  def match(data, []), do: {:ok, data}
+unless Application.compile_env(
+         :solid,
+         :omit_matchers_for_any,
+         Application.compile_env(:solid, :omit_all_matchers, false)
+       ) do
+  defimpl Solid.Matcher, for: Any do
+    def match(data, []), do: {:ok, data}
 
-  def match(_, _), do: {:error, :not_found}
+    def match(_, _), do: {:error, :not_found}
+  end
 end
 
-defimpl Solid.Matcher, for: List do
-  def match(data, []), do: {:ok, data}
+unless Application.compile_env(
+         :solid,
+         :omit_matchers_for_list,
+         Application.compile_env(:solid, :omit_all_matchers, false)
+       ) do
+  defimpl Solid.Matcher, for: List do
+    def match(data, []), do: {:ok, data}
 
-  def match(data, ["size"]) do
-    {:ok, Enum.count(data)}
-  end
+    def match(data, ["size"]) do
+      {:ok, Enum.count(data)}
+    end
 
-  def match(data, [key | keys]) when is_integer(key) do
-    case Enum.fetch(data, key) do
-      {:ok, value} -> @protocol.match(value, keys)
-      _ -> {:error, :not_found}
+    def match(data, [key | keys]) when is_integer(key) do
+      case Enum.fetch(data, key) do
+        {:ok, value} -> @protocol.match(value, keys)
+        _ -> {:error, :not_found}
+      end
     end
   end
 end
 
-defimpl Solid.Matcher, for: Map do
-  def match(data, []) do
-    {:ok, data}
-  end
-
-  def match(data, ["size"]) do
-    {:ok, Map.get(data, "size", Enum.count(data))}
-  end
-
-  def match(data, [key | []]) do
-    case Map.fetch(data, key) do
-      {:ok, value} -> {:ok, value}
-      _ -> {:error, :not_found}
+unless Application.compile_env(
+         :solid,
+         :omit_matchers_for_map,
+         Application.compile_env(:solid, :omit_all_matchers, false)
+       ) do
+  defimpl Solid.Matcher, for: Map do
+    def match(data, []) do
+      {:ok, data}
     end
-  end
 
-  def match(data, [key | keys]) do
-    case Map.fetch(data, key) do
-      {:ok, value} -> @protocol.match(value, keys)
-      _ -> {:error, :not_found}
+    def match(data, ["size"]) do
+      {:ok, Map.get(data, "size", Enum.count(data))}
+    end
+
+    def match(data, [key | []]) do
+      case Map.fetch(data, key) do
+        {:ok, value} -> {:ok, value}
+        _ -> {:error, :not_found}
+      end
+    end
+
+    def match(data, [key | keys]) do
+      case Map.fetch(data, key) do
+        {:ok, value} -> @protocol.match(value, keys)
+        _ -> {:error, :not_found}
+      end
     end
   end
 end
 
-defimpl Solid.Matcher, for: BitString do
-  def match(current, []), do: {:ok, current}
+unless Application.compile_env(
+         :solid,
+         :omit_matchers_for_bitstring,
+         Application.compile_env(:solid, :omit_all_matchers, false)
+       ) do
+  defimpl Solid.Matcher, for: BitString do
+    def match(current, []), do: {:ok, current}
 
-  def match(data, ["size"]) do
-    {:ok, String.length(data)}
-  end
+    def match(data, ["size"]) do
+      {:ok, String.length(data)}
+    end
 
-  def match(_data, [i | _]) when is_integer(i) do
-    {:error, :not_found}
-  end
+    def match(_data, [i | _]) when is_integer(i) do
+      {:error, :not_found}
+    end
 
-  def match(_data, [i | _]) when is_binary(i) do
-    {:error, :not_found}
+    def match(_data, [i | _]) when is_binary(i) do
+      {:error, :not_found}
+    end
   end
 end
 
-defimpl Solid.Matcher, for: Atom do
-  def match(current, []) when is_nil(current), do: {:ok, nil}
-  def match(data, []), do: {:ok, data}
-  def match(nil, _), do: {:error, :not_found}
+unless Application.compile_env(
+         :solid,
+         :omit_matchers_for_atom,
+         Application.compile_env(:solid, :omit_all_matchers, false)
+       ) do
+  defimpl Solid.Matcher, for: Atom do
+    def match(current, []) when is_nil(current), do: {:ok, nil}
+    def match(data, []), do: {:ok, data}
+    def match(nil, _), do: {:error, :not_found}
 
-  @doc """
-  Matches all remaining cases
-  """
-  def match(_current, [key]) when is_binary(key), do: {:error, :not_found}
+    @doc """
+    Matches all remaining cases
+    """
+    def match(_current, [key]) when is_binary(key), do: {:error, :not_found}
+  end
 end


### PR DESCRIPTION
After submitting my issue about breaking the built-in matcher implementations, I have after sleeping on it come to prefer the conditional compilation approach instead.

This change gives the Solid library consumer granular control to bring their own implemenation for individual matchers, but also to exclude the lot using a single configuration key.

Closes #136