### PR TITLE
Use a variable to access a hash

### DIFF
--- a/lib/solid/parser/variable.ex
+++ b/lib/solid/parser/variable.ex
@@ -8,7 +8,12 @@ defmodule Solid.Parser.Variable do
 
   def bracket_access do
     ignore(string("["))
-    |> choice([Literal.int(), Literal.single_quoted_string(), Literal.double_quoted_string()])
+    |> choice([
+      Literal.int(),
+      Literal.single_quoted_string(),
+      Literal.double_quoted_string(),
+      unwrap_and_tag(identifier(), :reference)
+    ])
     |> ignore(string("]"))
   end
 

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -53,6 +53,24 @@ defmodule Solid.ContextTest do
       assert Context.get_in(context, ["x"], [:vars, :counter_vars]) == {:ok, 2}
     end
 
+    test "counter_vars & vars scopes with nested access by a reference" do
+      context = %Context{
+        counter_vars: %{"x" => %{"y" => 1, "z" => "2"}},
+        vars: %{"variable" => "y"}
+      }
+
+      assert Context.get_in(context, ["x", {:reference, "variable"}], [:vars, :counter_vars]) == {:ok, 1}
+    end
+
+    test "missing reference" do
+      context = %Context{
+        counter_vars: %{"x" => %{"y" => %{"z" => "2"}}},
+        vars: %{"variable" => "q"}
+      }
+
+      assert Context.get_in(context, ["x", "y", {:reference, "missing"}], [:vars, :counter_vars]) == {:error, {:not_found, ["x", "y", "missing"]}}
+    end
+
     test "list access" do
       context = %Context{vars: %{"x" => ["a", "b", "c"]}}
       assert Context.get_in(context, ["x", 1], [:vars]) == {:ok, "b"}

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -59,7 +59,8 @@ defmodule Solid.ContextTest do
         vars: %{"variable" => "y"}
       }
 
-      assert Context.get_in(context, ["x", {:reference, "variable"}], [:vars, :counter_vars]) == {:ok, 1}
+      assert Context.get_in(context, ["x", {:reference, "variable"}], [:vars, :counter_vars]) ==
+               {:ok, 1}
     end
 
     test "missing reference" do
@@ -68,7 +69,8 @@ defmodule Solid.ContextTest do
         vars: %{"variable" => "q"}
       }
 
-      assert Context.get_in(context, ["x", "y", {:reference, "missing"}], [:vars, :counter_vars]) == {:error, {:not_found, ["x", "y", "missing"]}}
+      assert Context.get_in(context, ["x", "y", {:reference, "missing"}], [:vars, :counter_vars]) ==
+               {:error, {:not_found, ["x", "y", "missing"]}}
     end
 
     test "list access" do

--- a/test/integration/objects_test.exs
+++ b/test/integration/objects_test.exs
@@ -28,6 +28,67 @@ defmodule Solid.Integration.ObjectsTest do
     assert render("Number {{ key[1] }}", %{"key" => [1, 2, 3]}) == "Number 2"
   end
 
+  test "field access by literal string" do
+    template = """
+    {%- assign greeting = greetings['casual'].text -%}
+    <p>{{ greeting }} world</p>
+    """
+
+    data = %{
+      "greetings" => %{
+        "formal" => %{"text" => "Hello"},
+        "casual" => %{"text" => "Hey!"},
+        "friendly" => %{"text" => "Yo!"}
+      }
+    }
+
+    assert render(template, data) == """
+           <p>Hey! world</p>
+           """
+  end
+
+  test "field access by variable" do
+    template = """
+    {%- assign greet_as = 'friendly' -%}
+    {%- assign greeting = greetings[greet_as].text -%}
+    <p>{{ greeting }} world</p>
+    """
+
+    data = %{
+      "greetings" => %{
+        "formal" => %{"text" => "Hello"},
+        "casual" => %{"text" => "Hey!"},
+        "friendly" => %{"text" => "Yo!"}
+      }
+    }
+
+    assert render(template, data) == """
+    <p>Yo! world</p>
+    """
+  end
+
+  test "field access through many variables" do
+    template = """
+    {%- assign greet_as = 'casual' -%}
+    {%- assign really_greet_as = greet_as -%}
+    {%- assign really_really_greet_as = really_greet_as -%}
+    {%- assign greeting = greetings[really_really_greet_as].text -%}
+    <p>{{ greeting }} world</p>
+    """
+
+    data = %{
+      "greetings" => %{
+        "formal" => %{"text" => "Hello"},
+        "casual" => %{"text" => "Hey!"},
+        "friendly" => %{"text" => "Yo!"}
+      }
+    }
+
+    assert render(template, data) == """
+    <p>Hey! world</p>
+    """
+  end
+
   test "complex key rendering" do
     hash = %{"key1" => %{"key2" => %{"key3" => 123}}}
     assert render("Number {{ key1.key2.key3 }} !", hash) == "Number 123 !"

--- a/test/integration/objects_test.exs
+++ b/test/integration/objects_test.exs
@@ -63,8 +63,8 @@ defmodule Solid.Integration.ObjectsTest do
     }
 
     assert render(template, data) == """
-    <p>Yo! world</p>
-    """
+           <p>Yo! world</p>
+           """
   end
 
   test "field access through many variables" do
@@ -85,8 +85,8 @@ defmodule Solid.Integration.ObjectsTest do
     }
 
     assert render(template, data) == """
-    <p>Hey! world</p>
-    """
+           <p>Hey! world</p>
+           """
   end
 
   test "complex key rendering" do


### PR DESCRIPTION
I took a shot at fixing #142 

Added an identifier to object access (i.e. between `[..]`). The tricky part is that ends up as a string when reaching `Context.get_in/3`, so you can't know if you want to access that value or the value a variable points to.

So I tagged the value with `:reference` (maybe that's not a great name). Then `Context.get_in/3` has to resolve what value that variable points to.

I wrote a test showing that a variable pointing to a variable pointing to a variable works but that may "just work" because of how the Assign works. So maybe that test is unnecessary.

That seems to work but I'm not sure if there's a better way to do this.
