### PR TITLE
Adds support for empty per spec

### DIFF
--- a/lib/solid/expression.ex
+++ b/lib/solid/expression.ex
@@ -79,6 +79,10 @@ defmodule Solid.Expression do
   def eval({v1, :<, nil}) when is_number(v1), do: false
   def eval({nil, :>=, v2}) when is_number(v2), do: false
   def eval({nil, :>, v2}) when is_number(v2), do: false
+  def eval({v1, :==, :empty}) when is_list(v1), do: v1 == []
+  def eval({v1, :!=, :empty}) when is_list(v1), do: v1 != []
+  def eval({v1, :==, :empty}) when is_binary(v1), do: v1 == ""
+  def eval({v1, :!=, :empty}) when is_binary(v1), do: v1 != ""
   def eval({v1, op, v2}), do: apply(Kernel, op, [v1, v2])
 
   def eval(value) do

--- a/lib/solid/parser/literal.ex
+++ b/lib/solid/parser/literal.ex
@@ -38,22 +38,6 @@ defmodule Solid.Parser.Literal do
   end
 
   def value do
-    true_value =
-      string("true")
-      |> replace(true)
-
-    false_value =
-      string("false")
-      |> replace(false)
-
-    null =
-      string("nil")
-      |> replace(nil)
-
-    empty =
-      string("empty")
-      |> replace(:empty)
-
     frac =
       string(".")
       |> concat(integer(min: 1))
@@ -73,10 +57,6 @@ defmodule Solid.Parser.Literal do
     choice([
       float,
       int(),
-      true_value,
-      false_value,
-      null,
-      empty,
       single_quoted_string(),
       double_quoted_string()
     ])

--- a/lib/solid/parser/literal.ex
+++ b/lib/solid/parser/literal.ex
@@ -50,6 +50,10 @@ defmodule Solid.Parser.Literal do
       string("nil")
       |> replace(nil)
 
+    empty =
+      string("empty")
+      |> replace(:empty)
+
     frac =
       string(".")
       |> concat(integer(min: 1))
@@ -72,6 +76,7 @@ defmodule Solid.Parser.Literal do
       true_value,
       false_value,
       null,
+      empty,
       single_quoted_string(),
       double_quoted_string()
     ])

--- a/lib/solid/parser/variable.ex
+++ b/lib/solid/parser/variable.ex
@@ -26,5 +26,15 @@ defmodule Solid.Parser.Variable do
     identifier()
     |> repeat(choice([dot_access(), bracket_access()]))
     |> tag(:field)
+    |> map({__MODULE__, :reserved_words, []})
+  end
+
+  @reserved_words ~w(true false nil empty)
+
+  def reserved_words(field) do
+    case field do
+      {:field, [word]} when word in @reserved_words -> {:value, String.to_atom(word)}
+      _ -> field
+    end
   end
 end

--- a/test/cases/if/input.json
+++ b/test/cases/if/input.json
@@ -18,5 +18,6 @@
     }
   },
  "enabled?" : true,
-  "enabled2?" : false
+  "enabled2?" : false,
+  "var4": ""
 }

--- a/test/cases/if/input.liquid
+++ b/test/cases/if/input.liquid
@@ -27,6 +27,12 @@
 
 {% if array contains 1 %} true {% else %} false {% endif %}
 
+
+{% if array == empty %} true {% else %} false {% endif %}
+{% if array != empty %} true {% else %} false {% endif %}
+{% if var4 == empty %} true {% else %} false {% endif %}
+{% if var4 != empty %} true {% else %} false {% endif %}
+
 {% if string-array[1] == "b" %}
   letter b
 {% endif %}

--- a/test/cases/object/input.liquid
+++ b/test/cases/object/input.liquid
@@ -9,9 +9,9 @@
 {{ multiarray[12] }}
 {{ multiarray[-1][1] }}
 
-{{ empty[0][1] }}
-{{ empty[1][1] }}
-{{ empty[12] }}
+{{ nullobj[0][1] }}
+{{ nullobj[1][1] }}
+{{ nullobj[12] }}
 
 {{ string[0][1] }}
 {{ string[1][1] }}


### PR DESCRIPTION
This adds support for the `empty` keyword per [spec](https://shopify.github.io/liquid/basics/types/#emptydrop)

I think there's an issue where if a reserved word appears anywhere in the name of a var, it causes a problem. But this seems to occur for `nil` as well, so I think it's unrelated to this PR