### PR TITLE
Add support for key-value pair access after map iteration

### DIFF
--- a/lib/solid/matcher.ex
+++ b/lib/solid/matcher.ex
@@ -75,3 +75,20 @@ defimpl Solid.Matcher, for: Atom do
   """
   def match(_current, [key]) when is_binary(key), do: {:error, :not_found}
 end
+
+defimpl Solid.Matcher, for: Tuple do
+  def match(data, []), do: {:ok, data}
+
+  def match(data, ["size"]) do
+    {:ok, tuple_size(data)}
+  end
+
+  def match(data, [key | keys]) when is_integer(key) do
+    try do
+      elem(data, key)
+      |> @protocol.match(keys)
+    rescue
+      ArgumentError -> {:error, :not_found}
+    end
+  end
+end

--- a/test/cases/for/input.json
+++ b/test/cases/for/input.json
@@ -17,10 +17,6 @@
     }
   ],
   "hash": {
-    "lorem": 1,
-    "ipsum": 2,
-    "dolor": 3,
-    "sit": 4,
-    "amet": 5
+    "lorem": 1
   }
 }

--- a/test/cases/for/input.json
+++ b/test/cases/for/input.json
@@ -15,5 +15,12 @@
       "title": "vase",
       "type": "livingroom"
     }
-  ]
+  ],
+  "hash": {
+    "lorem": 1,
+    "ipsum": 2,
+    "dolor": 3,
+    "sit": 4,
+    "amet": 5
+  }
 }

--- a/test/cases/for/input.liquid
+++ b/test/cases/for/input.liquid
@@ -104,6 +104,10 @@ end for
   {{ forloop.index0 }}
 {% endfor %}
 
+{% for item in hash %}
+  {{ item[0] }} :: {{ item[1] }}
+{% endfor %}
+
 {% if enabled? %}
 ON
 {% else %}


### PR DESCRIPTION
This PR resolves #148, although the modified test case fails as Solid uses the builtin (unordered) maps whereas Liquid/Ruby appears to use ordered maps.

I tweaked the patch I included in the issue for when there are multiple accessors, but I'm not sure if that bit is correct.