### PR TITLE
fix: Return error when both strict variables and filters are enabled

### DIFF
--- a/lib/solid.ex
+++ b/lib/solid.ex
@@ -209,15 +209,10 @@ defmodule Solid do
   end
 
   defp strict_errors?(errors, options) do
-    cond do
-      options[:strict_variables] == true ->
-        Enum.any?(errors, &match?(%Solid.UndefinedVariableError{}, &1))
+    variable_errors? = Enum.any?(errors, &match?(%Solid.UndefinedVariableError{}, &1))
+    filter_errors? = Enum.any?(errors, &match?(%Solid.UndefinedFilterError{}, &1))
 
-      options[:strict_filters] == true ->
-        Enum.any?(errors, &match?(%Solid.UndefinedFilterError{}, &1))
-
-      true ->
-        false
-    end
+    (options[:strict_variables] == true && variable_errors?) ||
+      (options[:strict_filters] == true && filter_errors?)
   end
 end


### PR DESCRIPTION
Hello,

when both **strict_variables** and **strict_filters** options were enabled at the same time, the `Solid.render` function did not return an error if there was no strict variable error present at the same time. This is due to the precedence in the `cond` block.

The result was that the unknown filter errors were silently ignored, and the render function returned an :ok tuple. 


