### PR TITLE
Accept function as custom_filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,31 @@ end
 # 42
 ```
 
+Alternatively, you can pass a function to the `custom_filters` option. This allows
+your filters to access predefined state. An example use-case could be to allow the
+filters to render strings in the user's default locale (or to override it by
+argument).
+
+``` elixir
+user_locale = "en"
+
+"{{ number | format_number }}"
+|> Solid.parse!()
+|> Solid.render!(%{ "number" => 41}, custom_filters: fn
+  "format_number", [num] ->
+    {:ok, Cldr.Number.to_string(num, locale: user_locale)}
+
+  "format_number", [num, locale] ->
+    {:ok, Cldr.Number.to_string(num, locale: locale)}
+
+  _, _ ->
+    :error
+end)
+|> IO.puts()
+```
+
+The callback must return either `{:ok, value}` or `:error`.
+
 ## Strict rendering
 
 If there are any missing variables/filters and `strict_variables: true` or `strict_filters: true` are passed as options `Solid.render/3` returns `{:error, errors, result}` where errors is the list of collected errors and `result` is the rendered template.

--- a/lib/solid.ex
+++ b/lib/solid.ex
@@ -129,7 +129,7 @@ defmodule Solid do
 
   - `file_system`: a tuple of {FileSystemModule, options}. If this option is not specified, `Solid` uses `Solid.BlankFileSystem` which returns an error when the `render` tag is used. `Solid.LocalFileSystem` can be used or a custom module may be implemented. See `Solid.FileSystem` for more details.
 
-  - `custom_filters`: a module name where additional filters are defined. The base filters (those from `Solid.StandardFilter`) still can be used, however, custom filters always take precedence.
+  - `custom_filters`: a module name where additional filters are defined. The base filters (those from `Solid.StandardFilter`) still can be used, however, custom filters always take precedence. May also be a function that receives the filter name and the arguments and must return `{:ok, term} | :error`.
 
   - `strict_variables`: if `true`, it collects an error when a variable is referenced in the template, but not given in the map
 

--- a/test/solid/standard_filter_test.exs
+++ b/test/solid/standard_filter_test.exs
@@ -45,4 +45,31 @@ defmodule Solid.StandardFilterTest do
                }
     end
   end
+
+  test "it applies a function as custom filter" do
+    user_locale = "en"
+
+    custom_filters = fn
+      "format_number", [num] ->
+        {:ok, "#{user_locale}: #{num}"}
+
+      "format_number", [num, locale] ->
+        {:ok, "#{locale}: #{num}"}
+
+      _, _ ->
+        :error
+    end
+
+    assert "en: 41" ==
+             "{{ number | format_number }}"
+             |> Solid.parse!()
+             |> Solid.render!(%{"number" => 41}, custom_filters: custom_filters)
+             |> to_string()
+
+    assert "fr: 41" ==
+             "{{ number | format_number: 'fr' }}"
+             |> Solid.parse!()
+             |> Solid.render!(%{"number" => 41}, custom_filters: custom_filters)
+             |> to_string()
+  end
 end


### PR DESCRIPTION
In versions `0.*` it was possible to pass the opts to custom filters. It would attempt to call the filter with the opts appended to it first and then without the opts. This was lost in the transition to 1.0. The previous implementation could be problematic with, for example, default arguments, so I support it's removal, but I would still like the ability to pass context to filters that weren't explicitly passed in the template and I'd rather not resort to the process dict.

This PR adds makes it possible for the caller to completely implement the filter logic themselves and additional context can be taken from the lambda's scope.