### PR TITLE
Ignore find_correct_function for custom_filters callback

### DIFF
--- a/lib/solid/standard_filter.ex
+++ b/lib/solid/standard_filter.ex
@@ -25,7 +25,7 @@ defmodule Solid.StandardFilter do
     end
   end
 
-  defp find_correct_function(module, fn_name, arity, loc) do
+  defp find_correct_function(module, fn_name, arity, loc) when is_atom(module) do
     module.__info__(:functions)
     |> Enum.find(&(elem(&1, 0) == fn_name))
     |> case do
@@ -42,6 +42,8 @@ defmodule Solid.StandardFilter do
         :error
     end
   end
+
+  defp find_correct_function(_callback, _fn_name, _arity, _loc), do: :error
 
   defp apply_filter(mod_or_callback, func, args, loc) do
     if is_function(mod_or_callback, 2) do

--- a/test/solid/standard_filter_test.exs
+++ b/test/solid/standard_filter_test.exs
@@ -72,4 +72,15 @@ defmodule Solid.StandardFilterTest do
              |> Solid.render!(%{"number" => 41}, custom_filters: custom_filters)
              |> to_string()
   end
+
+  test "custom filter throw undefined error" do
+    assert ["41"] ==
+             "{{ number | format_number }}"
+             |> Solid.parse!()
+             |> Solid.render!(%{"number" => 41},
+               custom_filters: fn _func, _args ->
+                 apply(Map, :does_not_exist, [])
+               end
+             )
+  end
 end


### PR DESCRIPTION
In my previous MR I added the callback version of `custom_filters`. Sadly, I missed the case where, if the custom function called `apply` and it resulted in an `UndefinedFunctionError`, then the `find_correct_function` would be called but because it's a function instead of a module, `module.__info__(:functions)` will fail.