### PR TITLE
Fix incorrect content reversal in case tags.

### DIFF
--- a/lib/solid/tags/case_tag.ex
+++ b/lib/solid/tags/case_tag.ex
@@ -110,7 +110,7 @@ defmodule Solid.Tags.CaseTag do
             {{:else_block, else_block}, [inner_acc | acc], context}
         end)
 
-      {Enum.reverse(List.flatten(acc)), context}
+      {List.flatten(Enum.reverse(acc)), context}
     end
   end
 end

--- a/test/solid/integration/scenarios/case/input.liquid
+++ b/test/solid/integration/scenarios/case/input.liquid
@@ -37,3 +37,6 @@
 {% case condition %}{% when 1 or 2 or 3 or 3 %} its 1 or 2 or 3 {% when 4 %} its 4 {% endcase %}
 
 {%- case condition -%}{%- when 1 or 2 or 3 or 3 -%}{%- when 4 -%}{%- endcase %}
+
+Content order is maintained
+{%- case condition -%}{%- when 3 -%}<span>{{condition}}</span>{%- endcase %}


### PR DESCRIPTION
It looks like the issue was just a misplaced Enum.reverse. I think this fixes #190. I've also added a new integration test the output is now correct (and was incorrect before).