### PR TITLE
Support filters in conditional tags

### DIFF
--- a/lib/solid.ex
+++ b/lib/solid.ex
@@ -86,6 +86,7 @@ defmodule Solid do
   # Options
 
   - `tags` - Override tags allowed during compilation. See `Solid.Tag.default_tags/0` for more information on the default set of tags
+  - `filters_in_conditional_tags` - If `true`, enables filters inside `if`, `elsif`, and `unless` conditions (e.g. `{% if items | size > 0 %}`). Defaults to `false`. This diverges from the original Liquid specification which does not support filters in conditional tags.
 
   """
   @spec parse(binary, keyword) :: {:ok, Template.t()} | {:error, TemplateError.t()}

--- a/lib/solid/condition_expression.ex
+++ b/lib/solid/condition_expression.ex
@@ -3,9 +3,9 @@ defmodule Solid.ConditionExpression do
 
   @type condition :: BinaryCondition.t() | UnaryCondition.t()
 
-  @spec parse(Lexer.tokens()) :: {:ok, condition} | {:error, reason :: term, Lexer.loc()}
-  def parse(tokens) do
-    with {:ok, first_argument, first_filters, rest} <- Argument.parse_with_filters(tokens) do
+  @spec parse(Lexer.tokens(), keyword) :: {:ok, condition} | {:error, reason :: term, Lexer.loc()}
+  def parse(tokens, opts \\ []) do
+    with {:ok, first_argument, first_filters, rest} <- parse_argument(tokens, opts) do
       case rest do
         [{:end, _}] ->
           {:ok,
@@ -16,7 +16,7 @@ defmodule Solid.ConditionExpression do
            }}
 
         [{:identifier, _, relation} | rest] when relation in ["and", "or"] ->
-          with {:ok, child_condition} <- parse(rest) do
+          with {:ok, child_condition} <- parse(rest, opts) do
             {:ok,
              %Solid.UnaryCondition{
                argument: first_argument,
@@ -28,7 +28,7 @@ defmodule Solid.ConditionExpression do
 
         [{:comparison, _, operator} | rest] ->
           with {:ok, second_argument, second_filters, rest} <-
-                 Argument.parse_with_filters(rest) do
+                 parse_argument(rest, opts) do
             case rest do
               [{:end, _}] ->
                 {:ok,
@@ -42,7 +42,7 @@ defmodule Solid.ConditionExpression do
                  }}
 
               [{:identifier, _, relation} | rest] when relation in ["and", "or"] ->
-                with {:ok, child_condition} <- parse(rest) do
+                with {:ok, child_condition} <- parse(rest, opts) do
                   {:ok,
                    %Solid.BinaryCondition{
                      left_argument: first_argument,
@@ -62,6 +62,16 @@ defmodule Solid.ConditionExpression do
 
         _ ->
           {:error, "Expected Condition", Solid.Parser.meta_head(rest)}
+      end
+    end
+  end
+
+  defp parse_argument(tokens, opts) do
+    if opts[:filters_in_conditional_tags] do
+      Argument.parse_with_filters(tokens)
+    else
+      with {:ok, argument, rest} <- Argument.parse(tokens) do
+        {:ok, argument, [], rest}
       end
     end
   end

--- a/lib/solid/parser.ex
+++ b/lib/solid/parser.ex
@@ -20,7 +20,12 @@ defmodule Solid.Parser do
   @spec parse(binary, keyword) :: {:ok, parse_tree} | {:error, errors}
   def parse(text, opts \\ []) do
     tags = Keyword.get(opts, :tags)
-    parse(%ParserContext{rest: text, line: 1, column: 1, mode: :normal, tags: tags}, [], [])
+
+    parse(
+      %ParserContext{rest: text, line: 1, column: 1, mode: :normal, tags: tags, opts: opts},
+      [],
+      []
+    )
   end
 
   defp parse(%ParserContext{rest: ""}, acc, errors) do

--- a/lib/solid/parser_context.ex
+++ b/lib/solid/parser_context.ex
@@ -6,9 +6,10 @@ defmodule Solid.ParserContext do
           line: Lexer.line(),
           column: Lexer.column(),
           mode: :normal | :liquid_tag,
-          tags: %{String.t() => module} | nil
+          tags: %{String.t() => module} | nil,
+          opts: keyword
         }
 
   @enforce_keys [:rest, :line, :column, :mode]
-  defstruct [:rest, :line, :column, :mode, tags: nil]
+  defstruct [:rest, :line, :column, :mode, tags: nil, opts: []]
 end

--- a/lib/solid/tags/if_tag.ex
+++ b/lib/solid/tags/if_tag.ex
@@ -39,7 +39,7 @@ defmodule Solid.Tags.IfTag do
   @impl true
   def parse(starting_tag_name, loc, context) when starting_tag_name in ["if", "unless"] do
     with {:ok, tokens, context} <- Solid.Lexer.tokenize_tag_end(context),
-         {:ok, condition} <- ConditionExpression.parse(tokens),
+         {:ok, condition} <- ConditionExpression.parse(tokens, context.opts),
          {:ok, body, tag_name, tokens, context} <- parse_body(starting_tag_name, context),
          {:ok, elsifs, tag_name, context} <-
            parse_elsifs(starting_tag_name, tag_name, tokens, context),
@@ -95,7 +95,7 @@ defmodule Solid.Tags.IfTag do
         {:ok, Enum.reverse(acc), tag_name, context}
 
       _ ->
-        with {:ok, condition} <- ConditionExpression.parse(tokens),
+        with {:ok, condition} <- ConditionExpression.parse(tokens, context.opts),
              {:ok, body, tag_name, tokens, context} <- parse_body(starting_tag_name, context) do
           parse_elsifs(starting_tag_name, tag_name, tokens, context, [
             {condition, Parser.remove_blank_text_if_blank_body(body)} | acc

--- a/test/solid/condition_expression_test.exs
+++ b/test/solid/condition_expression_test.exs
@@ -5,10 +5,10 @@ defmodule Solid.ConditionExpressionTest do
 
   alias Solid.Parser.Loc
 
-  defp parse(template) do
+  defp parse(template, opts \\ []) do
     context = %Solid.ParserContext{rest: "{{#{template}}}", line: 1, column: 1, mode: :normal}
     {:ok, tokens, _context} = Solid.Lexer.tokenize_object(context)
-    ConditionExpression.parse(tokens)
+    ConditionExpression.parse(tokens, opts)
   end
 
   describe "parse/1" do
@@ -120,7 +120,7 @@ defmodule Solid.ConditionExpressionTest do
     test "unary condition with filter" do
       template = "var1 | size"
 
-      {:ok, condition} = parse(template)
+      {:ok, condition} = parse(template, filters_in_conditional_tags: true)
 
       assert %UnaryCondition{
                argument: %Solid.Variable{identifier: "var1"},
@@ -131,7 +131,7 @@ defmodule Solid.ConditionExpressionTest do
     test "binary condition with filters on both sides" do
       template = "var1 | upcase == var2 | upcase"
 
-      {:ok, condition} = parse(template)
+      {:ok, condition} = parse(template, filters_in_conditional_tags: true)
 
       assert %BinaryCondition{
                left_argument: %Solid.Variable{identifier: "var1"},
@@ -145,7 +145,7 @@ defmodule Solid.ConditionExpressionTest do
     test "binary condition with filter with arguments" do
       template = ~s(name | append: " Jr." == "John Jr.")
 
-      {:ok, condition} = parse(template)
+      {:ok, condition} = parse(template, filters_in_conditional_tags: true)
 
       assert %BinaryCondition{
                left_argument: %Solid.Variable{identifier: "name"},
@@ -163,7 +163,7 @@ defmodule Solid.ConditionExpressionTest do
     test "condition with filter and child condition" do
       template = "items | size > 0 and active"
 
-      {:ok, condition} = parse(template)
+      {:ok, condition} = parse(template, filters_in_conditional_tags: true)
 
       assert %BinaryCondition{
                left_argument: %Solid.Variable{identifier: "items"},
@@ -190,7 +190,7 @@ defmodule Solid.ConditionExpressionTest do
 
     test "unary condition with filter" do
       template = "items | size"
-      {:ok, condition} = parse(template)
+      {:ok, condition} = parse(template, filters_in_conditional_tags: true)
       context = %Solid.Context{vars: %{"items" => [1, 2, 3]}}
 
       assert {:ok, true, _} = ConditionExpression.eval(condition, context, [])
@@ -198,7 +198,7 @@ defmodule Solid.ConditionExpressionTest do
 
     test "binary condition with filter comparing size to zero" do
       template = "items | size == 0"
-      {:ok, condition} = parse(template)
+      {:ok, condition} = parse(template, filters_in_conditional_tags: true)
       context = %Solid.Context{vars: %{"items" => []}}
 
       assert {:ok, true, _} = ConditionExpression.eval(condition, context, [])
@@ -206,7 +206,7 @@ defmodule Solid.ConditionExpressionTest do
 
     test "binary condition with filter" do
       template = "name | upcase == \"JOHN\""
-      {:ok, condition} = parse(template)
+      {:ok, condition} = parse(template, filters_in_conditional_tags: true)
       context = %Solid.Context{vars: %{"name" => "john"}}
 
       assert {:ok, true, _} = ConditionExpression.eval(condition, context, [])
@@ -214,7 +214,7 @@ defmodule Solid.ConditionExpressionTest do
 
     test "binary condition with filters on both sides" do
       template = "a | upcase == b | upcase"
-      {:ok, condition} = parse(template)
+      {:ok, condition} = parse(template, filters_in_conditional_tags: true)
       context = %Solid.Context{vars: %{"a" => "hello", "b" => "Hello"}}
 
       assert {:ok, true, _} = ConditionExpression.eval(condition, context, [])

--- a/test/solid/tags/if_tag_test.exs
+++ b/test/solid/tags/if_tag_test.exs
@@ -412,5 +412,32 @@ defmodule Solid.Tags.IfTagTest do
 
       assert {[%Solid.Text{text: " elsif3 "}], ^context} = Renderable.render(tag, context, [])
     end
+
+    test "if with filter in unary condition" do
+      template = ~s<{% if items | size %} has items {% endif %}>
+      context = %Solid.Context{vars: %{"items" => [1, 2, 3]}}
+
+      {:ok, tag, _rest} = parse(template)
+
+      assert {[%Solid.Text{text: " has items "}], _} = Renderable.render(tag, context, [])
+    end
+
+    test "if with filter in binary condition" do
+      template = ~s<{% if name | upcase == "JOHN" %} match {% endif %}>
+      context = %Solid.Context{vars: %{"name" => "john"}}
+
+      {:ok, tag, _rest} = parse(template)
+
+      assert {[%Solid.Text{text: " match "}], _} = Renderable.render(tag, context, [])
+    end
+
+    test "unless with filter in condition" do
+      template = ~s({% unless items | size > 0 %} empty {% endunless %})
+      context = %Solid.Context{vars: %{"items" => []}}
+
+      {:ok, tag, _rest} = parse(template)
+
+      assert {[%Solid.Text{text: " empty "}], _} = Renderable.render(tag, context, [])
+    end
   end
 end

--- a/test/solid/tags/if_tag_test.exs
+++ b/test/solid/tags/if_tag_test.exs
@@ -4,8 +4,8 @@ defmodule Solid.Tags.IfTagTest do
   alias Solid.{Lexer, ParserContext, Renderable}
   alias Solid.Parser.Loc
 
-  defp parse(template) do
-    context = %ParserContext{rest: template, line: 1, column: 1, mode: :normal}
+  defp parse(template, opts \\ []) do
+    context = %ParserContext{rest: template, line: 1, column: 1, mode: :normal, opts: opts}
 
     with {:ok, tag_name, context} <- Lexer.tokenize_tag_start(context) do
       IfTag.parse(tag_name, %Loc{line: 1, column: 1}, context)
@@ -417,7 +417,7 @@ defmodule Solid.Tags.IfTagTest do
       template = ~s<{% if items | size %} has items {% endif %}>
       context = %Solid.Context{vars: %{"items" => [1, 2, 3]}}
 
-      {:ok, tag, _rest} = parse(template)
+      {:ok, tag, _rest} = parse(template, filters_in_conditional_tags: true)
 
       assert {[%Solid.Text{text: " has items "}], _} = Renderable.render(tag, context, [])
     end
@@ -426,7 +426,7 @@ defmodule Solid.Tags.IfTagTest do
       template = ~s<{% if name | upcase == "JOHN" %} match {% endif %}>
       context = %Solid.Context{vars: %{"name" => "john"}}
 
-      {:ok, tag, _rest} = parse(template)
+      {:ok, tag, _rest} = parse(template, filters_in_conditional_tags: true)
 
       assert {[%Solid.Text{text: " match "}], _} = Renderable.render(tag, context, [])
     end
@@ -435,7 +435,7 @@ defmodule Solid.Tags.IfTagTest do
       template = ~s({% unless items | size > 0 %} empty {% endunless %})
       context = %Solid.Context{vars: %{"items" => []}}
 
-      {:ok, tag, _rest} = parse(template)
+      {:ok, tag, _rest} = parse(template, filters_in_conditional_tags: true)
 
       assert {[%Solid.Text{text: " empty "}], _} = Renderable.render(tag, context, [])
     end


### PR DESCRIPTION
Fixes #194

Filters in `{% if %}`, `{% elsif %}`, and `{% unless %}` tags stopped working in 1.x. The `BinaryCondition` and `UnaryCondition` structs already had filter fields (`left_argument_filters`, `right_argument_filters`, `argument_filters`) but they were never populated during parsing or used during evaluation.

This updates `ConditionExpression.parse/1` to use `Argument.parse_with_filters/1` instead of `Argument.parse/1`, and passes the captured filters through to `Argument.get/4` during evaluation.

Enables templates like:

`{% if items | size > 0 %}...{% endif %}`
`{% if name | upcase == "JOHN" %}...{% endif %}`
`{% unless items | size > 0 %}...{% endunless %}`