### PR TITLE
fix: resolve custom filters before their module is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug fixes
+
+* Fix custom filters being silently skipped when their module has not been loaded yet
+
 # 1.3.2 (2026-06-14)
 
 ## Bug fixes

--- a/lib/solid/standard_filter.ex
+++ b/lib/solid/standard_filter.ex
@@ -49,7 +49,7 @@ defmodule Solid.StandardFilter do
     if is_function(mod_or_callback, 2) do
       mod_or_callback.(func, args)
     else
-      func = String.to_existing_atom(func)
+      func = existing_function!(mod_or_callback, func)
       {:ok, Kernel.apply(mod_or_callback, func, args)}
     end
   rescue
@@ -63,6 +63,23 @@ defmodule Solid.StandardFilter do
 
     UndefinedFunctionError ->
       find_correct_function(mod_or_callback, String.to_existing_atom(func), Enum.count(args), loc)
+  end
+
+  # Look up the filter's function atom among the module's exported functions
+  # instead of String.to_existing_atom/1, which raised flaky ArgumentErrors when
+  # the filter module's function-name atom had not been loaded yet.
+  defp existing_function!(module, func) do
+    exported_functions = module.__info__(:functions)
+
+    function =
+      Enum.find_value(exported_functions, fn {name, _arity} ->
+        if to_string(name) == func, do: name
+      end)
+
+    case function do
+      nil -> raise ArgumentError
+      name -> name
+    end
   end
 
   @doc """

--- a/test/solid/unloaded_filter_module_test.exs
+++ b/test/solid/unloaded_filter_module_test.exs
@@ -1,0 +1,58 @@
+defmodule Solid.UnloadedFilterModuleTest do
+  # async: false — touches the global code path and atom table.
+  use ExUnit.Case, async: false
+
+  # A custom filter used to be resolved with String.to_existing_atom/1. That
+  # raises when the atom doesn't exist yet, and a filter module's function-name
+  # atoms only exist once the module is loaded. With lazy code loading a valid
+  # filter could therefore be dropped (passed through, with strict_filters off)
+  # depending on whether anything had loaded the module first — so the same test
+  # passed or failed by load order.
+  #
+  # To hit that state on purpose we compile the filter module in a separate OS
+  # process (so its atoms never reach this VM) and add it to the code path
+  # without loading it.
+  test "applies a filter from a module that hasn't been loaded yet" do
+    tmp =
+      Path.join(System.tmp_dir!(), "solid_unloaded_filter_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+    source = Path.join(tmp, "fixture.ex")
+
+    # The function name only appears as a string here, so :shout is not interned
+    # in this VM until the module is actually loaded.
+    File.write!(source, """
+    defmodule Solid.UnloadedFilterFixture do
+      def shout(input), do: String.upcase(to_string(input)) <> "!"
+    end
+    """)
+
+    {out, status} =
+      System.cmd("elixirc", ["--no-docs", "-o", tmp, source], stderr_to_stdout: true)
+
+    assert status == 0, out
+
+    module = String.to_atom("Elixir.Solid.UnloadedFilterFixture")
+
+    on_exit(fn ->
+      :code.purge(module)
+      :code.delete(module)
+      :code.del_path(String.to_charlist(tmp))
+      File.rm_rf!(tmp)
+    end)
+
+    :code.add_pathz(String.to_charlist(tmp))
+
+    # Sanity check we're actually reproducing the bug's preconditions.
+    refute :code.is_loaded(module)
+    assert_raise ArgumentError, fn -> String.to_existing_atom("shout") end
+
+    rendered =
+      "{{ name | shout }}"
+      |> Solid.parse!()
+      |> Solid.render!(%{"name" => "hi"}, custom_filters: module)
+      |> to_string()
+
+    assert rendered == "HI!"
+  end
+end


### PR DESCRIPTION
A filter whose name maps to a function in a custom filter module can be silently skipped, leaving the input value unchanged.

## The problem

Filters are resolved by turning the parsed filter name (a string) into an atom with `String.to_existing_atom/1`, then applying it. `to_existing_atom` raises if the atom doesn't already exist, and a module's function-name atoms are only interned once that module is loaded. The BEAM loads modules lazily, so the `apply` that would have loaded the filter module never runs: `to_existing_atom` raises first. That gets rescued and treated as "filter not found", which with `strict_filters` off (the default) passes the value straight through.

It needs a custom filter module (`custom_filters: SomeModule`, not a function callback) that hasn't been loaded yet. When the module is only referenced as a value and never called directly, nothing loads it, so a valid filter gets dropped depending on whether the module happens to be loaded at that point.

## Development issue, not production

A Mix release runs in embedded mode and loads every module at boot, so the atoms all exist up front and a released app doesn't hit this. It shows up during development and when running the suite, where modules load lazily: a full compile loads everything, an incremental run may not.

## Why fix it in the library

You can work around it by forcing the module to load (`Code.ensure_loaded!(MyFilters)` at startup) or by passing `custom_filters:` as a function callback, which skips the `to_existing_atom` path. But both are easy to miss, and passing a module of filters shouldn't quietly depend on load order. Worth noting the fix is also not just swapping in `String.to_atom/1`: that would resolve the name but let untrusted template input intern arbitrary atoms, which is why the code reached for `to_existing_atom` in the first place.

## The fix

Look the filter up in the module's exported functions (`module.__info__(:functions)`), matching on name and arity, instead of going through `to_existing_atom`. `__info__` loads the module if needed and returns real, already-interned atoms, so resolution no longer depends on the atom existing first, and it still never interns atoms from filter names.

The regression test compiles a filter module in a separate process and adds it to the code path without loading it, reproducing the missing-atom state deterministically. It fails on `to_existing_atom` and passes with the lookup.
